### PR TITLE
Add basic JSON snapshotter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leagueofcomicgeeks",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -843,6 +843,17 @@
         "mime-types": "2.1.18"
       }
     },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1203,6 +1214,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -2062,6 +2082,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.12.0",
+    "fs-extra": "^6.0.1",
     "jasmine": "^3.1.0",
     "sinon": "^6.0.0"
   }

--- a/test/logged-in/collection/issues-list.spec.js
+++ b/test/logged-in/collection/issues-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allIssuesCollection = require('./test-data/all-issues-collection');
 
 module.exports = function (lofcg) {
   const additionalArgs = [];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added issue', function (done) {
           lofcg.collection.get(editableUserId, (err, collection) => {
             expect(err).toBeNull();
-            expect(collection.length).toBe(1);
-            expect(collection).toEqual(allIssuesCollection);
+            expect(collection).toMatchJsonSnapshot('all-issues-collection');
             _.each(collection, (comic) => {
               expect(comic).toBeAComicIssue();
             });

--- a/test/logged-in/collection/series-list.spec.js
+++ b/test/logged-in/collection/series-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allSeriesCollection = require('./test-data/all-series-collection');
 
 module.exports = function (lofcg) {
   const additionalArgs = [{ type: lofcg.types.SERIES }];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added series', function (done) {
           lofcg.collection.get(editableUserId, { type: lofcg.types.SERIES }, (err, collection) => {
             expect(err).toBeNull();
-            expect(collection.length).toBe(1);
-            expect(collection).toEqual(allSeriesCollection);
+            expect(collection).toMatchJsonSnapshot('all-series-collection');
             _.each(collection, (comic) => {
               expect(comic).toBeAComicSeries();
             });

--- a/test/logged-in/pull-list/issues-list.spec.js
+++ b/test/logged-in/pull-list/issues-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allIssuesPullList = require('./test-data/all-issues-pull-list');
 
 module.exports = function (lofcg, pullListDate) {
   const modificationPullListDate = '2017-04-05';
@@ -28,8 +27,7 @@ module.exports = function (lofcg, pullListDate) {
         it('should contain the previously added issue', function (done) {
           lofcg.pullList.get(editableUserId, modificationPullListDate, (err, pullList) => {
             expect(err).toBeNull();
-            expect(pullList.length).toBe(1);
-            expect(pullList).toEqual(allIssuesPullList);
+            expect(pullList).toMatchJsonSnapshot('all-issues-pull-list');
             _.each(pullList, (comic) => {
               expect(comic).toBeAComicIssue();
             });

--- a/test/logged-in/pull-list/series-list.spec.js
+++ b/test/logged-in/pull-list/series-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allSeriesPullList = require('./test-data/all-series-pull-list');
 
 module.exports = function (lofcg, pullListDate) {
   const testFutureSeriesId = 131521; // Henry Roscoe: Detective, Sort of
@@ -34,8 +33,7 @@ module.exports = function (lofcg, pullListDate) {
         it('should contain an issue from the previously added series', function (done) {
           lofcg.pullList.get(editableUserId, futurePullListDate, { type: lofcg.types.SERIES }, (err, pullList) => {
             expect(err).toBeNull();
-            expect(pullList.length).toBe(1);
-            expect(pullList).toEqual(allSeriesPullList);
+            expect(pullList).toMatchJsonSnapshot('all-series-pull-list');
             _.each(pullList, (comic) => {
               expect(comic).toBeAComicSeries();
             });
@@ -62,7 +60,6 @@ module.exports = function (lofcg, pullListDate) {
           it('should not contain an issue from the previously added series', function (done) {
             lofcg.pullList.get(editableUserId, futurePullListDate, { type: lofcg.types.SERIES }, (err, pullList) => {
               expect(err).toBeNull();
-              expect(pullList.length).toBe(0);
               expect(pullList).toEqual([]);
               done();
             });
@@ -86,7 +83,6 @@ module.exports = function (lofcg, pullListDate) {
           it('should be empty pull list', function (done) {
             lofcg.pullList.get(editableUserId, pastPullListDate, { type: lofcg.types.SERIES }, (err, pullList) => {
               expect(err).toBeNull();
-              expect(pullList.length).toBe(0);
               expect(pullList).toEqual([]);
               done();
             });
@@ -127,7 +123,6 @@ module.exports = function (lofcg, pullListDate) {
         it('should be empty and not added historical issues to pull list', function (done) {
           lofcg.pullList.get(editableUserId, pastPullListDate, { type: lofcg.types.SERIES }, (err, pullList) => {
             expect(err).toBeNull();
-            expect(pullList.length).toBe(0);
             expect(pullList).toEqual([]);
             done();
           });

--- a/test/logged-in/read-list/issues-list.spec.js
+++ b/test/logged-in/read-list/issues-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allIssuesReadList = require('./test-data/all-issues-read-list');
 
 module.exports = function (lofcg) {
   const additionalArgs = [];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added issue', function (done) {
           lofcg.readList.get(editableUserId, (err, readList) => {
             expect(err).toBeNull();
-            expect(readList.length).toBe(1);
-            expect(readList).toEqual(allIssuesReadList);
+            expect(readList).toMatchJsonSnapshot('all-issues-read-list');
             _.each(readList, (comic) => {
               expect(comic).toBeAComicIssue();
             });

--- a/test/logged-in/read-list/series-list.spec.js
+++ b/test/logged-in/read-list/series-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allSeriesReadList = require('./test-data/all-series-read-list');
 
 module.exports = function (lofcg) {
   const additionalArgs = [{ type: lofcg.types.SERIES }];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added series', function (done) {
           lofcg.readList.get(editableUserId, { type: lofcg.types.SERIES }, (err, readList) => {
             expect(err).toBeNull();
-            expect(readList.length).toBe(1);
-            expect(readList).toEqual(allSeriesReadList);
+            expect(readList).toMatchJsonSnapshot('all-series-read-list');
             _.each(readList, (comic) => {
               expect(comic).toBeAComicSeries();
             });

--- a/test/logged-in/wish-list/issues-list.spec.js
+++ b/test/logged-in/wish-list/issues-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allIssuesWishList = require('./test-data/all-issues-wish-list');
 
 module.exports = function (lofcg) {
   const additionalArgs = [];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added issue', function (done) {
           lofcg.wishList.get(editableUserId, (err, wishList) => {
             expect(err).toBeNull();
-            expect(wishList.length).toBe(1);
-            expect(wishList).toEqual(allIssuesWishList);
+            expect(wishList).toMatchJsonSnapshot('all-issues-wish-list');
             _.each(wishList, (comic) => {
               expect(comic).toBeAComicIssue();
             });

--- a/test/logged-in/wish-list/series-list.spec.js
+++ b/test/logged-in/wish-list/series-list.spec.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const helpers = require('../../utils/helper-tests');
-const allSeriesWishList = require('./test-data/all-series-wish-list');
 
 module.exports = function (lofcg) {
   const additionalArgs = [{ type: lofcg.types.SERIES }];
@@ -27,8 +26,7 @@ module.exports = function (lofcg) {
         it('should contain the previously added series', function (done) {
           lofcg.wishList.get(editableUserId, { type: lofcg.types.SERIES }, (err, wishList) => {
             expect(err).toBeNull();
-            expect(wishList.length).toBe(1);
-            expect(wishList).toEqual(allSeriesWishList);
+            expect(wishList).toMatchJsonSnapshot('all-series-wish-list');
             _.each(wishList, (comic) => {
               expect(comic).toBeAComicSeries();
             });

--- a/test/shared/collection/issues-list.spec.js
+++ b/test/shared/collection/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssuesCollection = require('./test-data/all-issues-collection');
-const filteredIssuesCollection = require('./test-data/filtered-issues-collection');
-const sortedIssuesCollection = require('./test-data/sorted-issues-collection');
 
 module.exports = function (lofcg) {
   describe('get issues list', function () {
     it('should provide no comics in collection with an invalid user id', function (done) {
       lofcg.collection.get('foo', (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(0);
         expect(collection).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(86);
-        expect(collection).toEqual(allIssuesCollection);
+        expect(collection).toMatchJsonSnapshot('all-issues-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, { publishers: ['Image Comics'] }, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(13);
-        expect(collection).toEqual(filteredIssuesCollection);
+        expect(collection).toMatchJsonSnapshot('filtered-issues-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, { sort: 'desc' }, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(86);
-        expect(collection).toEqual(sortedIssuesCollection);
+        expect(collection).toMatchJsonSnapshot('sorted-issues-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/collection/series-list.spec.js
+++ b/test/shared/collection/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeriesCollection = require('./test-data/all-series-collection');
-const filteredSeriesCollection = require('./test-data/filtered-series-collection');
-const sortedSeriesCollection = require('./test-data/sorted-series-collection');
 
 module.exports = function (lofcg) {
   const options = { type: lofcg.types.SERIES };
@@ -12,7 +9,6 @@ module.exports = function (lofcg) {
     it('should provide no comics in collection with an invalid user id', function (done) {
       lofcg.collection.get('foo', options, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(0);
         expect(collection).toEqual([]);
         done();
       });
@@ -21,8 +17,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, options, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(3);
-        expect(collection).toEqual(allSeriesCollection);
+        expect(collection).toMatchJsonSnapshot('all-series-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -33,8 +28,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, filteredOptions, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(1);
-        expect(collection).toEqual(filteredSeriesCollection);
+        expect(collection).toMatchJsonSnapshot('filtered-series-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -45,8 +39,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users collection', function (done) {
       lofcg.collection.get(readonlyUserId, sortedOptions, (err, collection) => {
         expect(err).toBeNull();
-        expect(collection.length).toBe(3);
-        expect(collection).toEqual(sortedSeriesCollection);
+        expect(collection).toMatchJsonSnapshot('sorted-series-collection');
         _.each(collection, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/shared/new-comics/issues-list.spec.js
+++ b/test/shared/new-comics/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssues20160104 = require('./test-data/all-issues-2016-01-04');
-const filteredIssues20160104 = require('./test-data/filtered-issues-2016-01-04');
-const sortedIssues20160104 = require('./test-data/sorted-issues-2016-01-04');
 
 module.exports = function (lofcg, newComicsDate) {
   describe('get issues list', function () {
     it('should provide no new comic', function (done) {
       lofcg.newComics.get('1966-01-01', (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(0);
         expect(newComics).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a list of new comics', function (done) {
       lofcg.newComics.get(newComicsDate, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(243);
-        expect(newComics).toEqual(allIssues20160104);
+        expect(newComics).toMatchJsonSnapshot('all-issues-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a filtered list of new comics', function (done) {
       lofcg.newComics.get(newComicsDate, { publishers: ['Image Comics'] }, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(12);
-        expect(newComics).toEqual(filteredIssues20160104);
+        expect(newComics).toMatchJsonSnapshot('filtered-issues-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a sorted list of new comics', function (done) {
       lofcg.newComics.get(newComicsDate, { sort: 'desc' }, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(243);
-        expect(newComics).toEqual(sortedIssues20160104);
+        expect(newComics).toMatchJsonSnapshot('sorted-issues-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/new-comics/series-list.spec.js
+++ b/test/shared/new-comics/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeries20160104 = require('./test-data/all-series-2016-01-04');
-const filteredSeries20160104 = require('./test-data/filtered-series-2016-01-04');
-const sortedSeries20160104 = require('./test-data/sorted-series-2016-01-04');
 
 module.exports = function (lofcg, newComicsDate) {
   const options = { type: lofcg.types.SERIES };
@@ -12,7 +9,6 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide no new comic series', function (done) {
       lofcg.newComics.get('1966-01-01', options, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(0);
         expect(newComics).toEqual([]);
         done();
       });
@@ -21,8 +17,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a list of new comic series', function (done) {
       lofcg.newComics.get(newComicsDate, options, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(148);
-        expect(newComics).toEqual(allSeries20160104);
+        expect(newComics).toMatchJsonSnapshot('all-series-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -33,8 +28,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a filtered list of new comic series', function (done) {
       lofcg.newComics.get(newComicsDate, filteredOptions, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(11);
-        expect(newComics).toEqual(filteredSeries20160104);
+        expect(newComics).toMatchJsonSnapshot('filtered-series-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -45,8 +39,7 @@ module.exports = function (lofcg, newComicsDate) {
     it('should provide a sorted list of new comic series', function (done) {
       lofcg.newComics.get(newComicsDate, sortedOptions, (err, newComics) => {
         expect(err).toBeNull();
-        expect(newComics.length).toBe(148);
-        expect(newComics).toEqual(sortedSeries20160104);
+        expect(newComics).toMatchJsonSnapshot('sorted-series-2016-01-04');
         _.each(newComics, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/shared/pull-list/issues-list.spec.js
+++ b/test/shared/pull-list/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssuesPullList = require('./test-data/all-issues-pull-list');
-const filteredIssuesPullList = require('./test-data/filtered-issues-pull-list');
-const sortedIssuesPullList = require('./test-data/sorted-issues-pull-list');
 
 module.exports = function (lofcg, pullListDate) {
   describe('get issues list', function () {
     it('should provide no comics in pull list with an invalid user id', function (done) {
       lofcg.pullList.get('foo', pullListDate, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(0);
         expect(pullList).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(allIssuesPullList);
+        expect(pullList).toMatchJsonSnapshot('all-issues-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a filtered list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, { publishers: ['Image Comics'] }, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(1);
-        expect(pullList).toEqual(filteredIssuesPullList);
+        expect(pullList).toMatchJsonSnapshot('filtered-issues-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a sorted list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, { sort: 'desc' }, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(sortedIssuesPullList);
+        expect(pullList).toMatchJsonSnapshot('sorted-issues-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -53,8 +46,8 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a custom sorted list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, { sort: 'pulls' }, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(sortedIssuesPullList); // Custom sorting is the same order as descending
+        // Custom sorting is the same order as descending
+        expect(pullList).toMatchJsonSnapshot('sorted-issues-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/pull-list/series-list.spec.js
+++ b/test/shared/pull-list/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeriesPullList = require('./test-data/all-series-pull-list');
-const filteredSeriesPullList = require('./test-data/filtered-series-pull-list');
-const sortedSeriesPullList = require('./test-data/sorted-series-pull-list');
 
 module.exports = function (lofcg, pullListDate) {
   const options = { type: lofcg.types.SERIES };
@@ -13,7 +10,6 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide no comics in pull list with an invalid user id', function (done) {
       lofcg.pullList.get('foo', pullListDate, options, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(0);
         expect(pullList).toEqual([]);
         done();
       });
@@ -22,8 +18,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, options, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(allSeriesPullList);
+        expect(pullList).toMatchJsonSnapshot('all-series-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -34,8 +29,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a filtered list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, filteredOptions, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(1);
-        expect(pullList).toEqual(filteredSeriesPullList);
+        expect(pullList).toMatchJsonSnapshot('filtered-series-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -46,8 +40,7 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a sorted list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, sortedOptions, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(sortedSeriesPullList);
+        expect(pullList).toMatchJsonSnapshot('sorted-series-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -58,8 +51,8 @@ module.exports = function (lofcg, pullListDate) {
     it('should provide a custom sorted list of comics from a users pull list', function (done) {
       lofcg.pullList.get(readonlyUserId, pullListDate, customSortedOptions, (err, pullList) => {
         expect(err).toBeNull();
-        expect(pullList.length).toBe(2);
-        expect(pullList).toEqual(allSeriesPullList); // Custom sorting does not apply to series
+        // Custom sorting does not apply to series
+        expect(pullList).toMatchJsonSnapshot('all-series-pull-list');
         _.each(pullList, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/shared/read-list/issues-list.spec.js
+++ b/test/shared/read-list/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssuesReadList = require('./test-data/all-issues-read-list');
-const filteredIssuesReadList = require('./test-data/filtered-issues-read-list');
-const sortedIssuesReadList = require('./test-data/sorted-issues-read-list');
 
 module.exports = function (lofcg) {
   describe('get issues list', function () {
     it('should provide no comics in read list with an invalid user id', function (done) {
       lofcg.readList.get('foo', (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(0);
         expect(readList).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(34);
-        expect(readList).toEqual(allIssuesReadList);
+        expect(readList).toMatchJsonSnapshot('all-issues-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, { publishers: ['Image Comics'] }, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(13);
-        expect(readList).toEqual(filteredIssuesReadList);
+        expect(readList).toMatchJsonSnapshot('filtered-issues-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, { sort: 'desc' }, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(34);
-        expect(readList).toEqual(sortedIssuesReadList);
+        expect(readList).toMatchJsonSnapshot('sorted-issues-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/read-list/series-list.spec.js
+++ b/test/shared/read-list/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeriesReadList = require('./test-data/all-series-read-list');
-const filteredSeriesReadList = require('./test-data/filtered-series-read-list');
-const sortedSeriesReadList = require('./test-data/sorted-series-read-list');
 
 module.exports = function (lofcg) {
   const options = { type: lofcg.types.SERIES };
@@ -12,7 +9,6 @@ module.exports = function (lofcg) {
     it('should provide no comics in read list with an invalid user id', function (done) {
       lofcg.readList.get('foo', options, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(0);
         expect(readList).toEqual([]);
         done();
       });
@@ -21,8 +17,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, options, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(4);
-        expect(readList).toEqual(allSeriesReadList);
+        expect(readList).toMatchJsonSnapshot('all-series-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -33,8 +28,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, filteredOptions, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(1);
-        expect(readList).toEqual(filteredSeriesReadList);
+        expect(readList).toMatchJsonSnapshot('filtered-series-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -45,8 +39,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users read list', function (done) {
       lofcg.readList.get(readonlyUserId, sortedOptions, (err, readList) => {
         expect(err).toBeNull();
-        expect(readList.length).toBe(4);
-        expect(readList).toEqual(sortedSeriesReadList);
+        expect(readList).toMatchJsonSnapshot('sorted-series-read-list');
         _.each(readList, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/shared/search-results/issues-list.spec.js
+++ b/test/shared/search-results/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssuesSeductionOfTheInnocent = require('./test-data/all-issues-seduction-of-the-innocent');
-const filteredIssuesSeductionOfTheInnocent = require('./test-data/filtered-issues-seduction-of-the-innocent');
-const sortedIssuesSeductionOfTheInnocent = require('./test-data/sorted-issues-seduction-of-the-innocent');
 
 module.exports = function (lofcg, searchTerm) {
   describe('get issues list', function () {
     it('should provide no results for unknown search term', function (done) {
       lofcg.searchResults.get('foobarbaz', (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(0);
         expect(searchResults).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide results for known search term', function (done) {
       lofcg.searchResults.get(searchTerm, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(13);
-        expect(searchResults).toEqual(allIssuesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('all-issues-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide a filtered list of search results', function (done) {
       lofcg.searchResults.get(searchTerm, { publishers: ['Dynamite'] }, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(5);
-        expect(searchResults).toEqual(filteredIssuesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('filtered-issues-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide a sorted list of search results', function (done) {
       lofcg.searchResults.get(searchTerm, { sort: 'desc' }, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(13);
-        expect(searchResults).toEqual(sortedIssuesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('sorted-issues-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/search-results/series-list.spec.js
+++ b/test/shared/search-results/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeriesSeductionOfTheInnocent = require('./test-data/all-series-seduction-of-the-innocent');
-const filteredSeriesSeductionOfTheInnocent = require('./test-data/filtered-series-seduction-of-the-innocent');
-const sortedSeriesSeductionOfTheInnocent = require('./test-data/sorted-series-seduction-of-the-innocent');
 
 module.exports = function (lofcg, searchTerm) {
   const options = { type: lofcg.types.SERIES };
@@ -12,7 +9,6 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide no results for unknown search term', function (done) {
       lofcg.searchResults.get('foobarbaz', options, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(0);
         expect(searchResults).toEqual([]);
         done();
       });
@@ -21,8 +17,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide results for known search term', function (done) {
       lofcg.searchResults.get(searchTerm, options, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(3);
-        expect(searchResults).toEqual(allSeriesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('all-series-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -33,8 +28,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide a filtered list of search results', function (done) {
       lofcg.searchResults.get(searchTerm, filteredOptions, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(1);
-        expect(searchResults).toEqual(filteredSeriesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('filtered-series-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -45,8 +39,7 @@ module.exports = function (lofcg, searchTerm) {
     it('should provide a sorted list of search results', function (done) {
       lofcg.searchResults.get(searchTerm, sortedOptions, (err, searchResults) => {
         expect(err).toBeNull();
-        expect(searchResults.length).toBe(3);
-        expect(searchResults).toEqual(sortedSeriesSeductionOfTheInnocent);
+        expect(searchResults).toMatchJsonSnapshot('sorted-series-seduction-of-the-innocent');
         _.each(searchResults, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/shared/wish-list/issues-list.spec.js
+++ b/test/shared/wish-list/issues-list.spec.js
@@ -1,14 +1,10 @@
 const _ = require('lodash');
-const allIssuesWishList = require('./test-data/all-issues-wish-list');
-const filteredIssuesWishList = require('./test-data/filtered-issues-wish-list');
-const sortedIssuesWishList = require('./test-data/sorted-issues-wish-list');
 
 module.exports = function (lofcg) {
   describe('get issues list', function () {
     it('should provide no comics in wish list with an invalid user id', function (done) {
       lofcg.wishList.get('foo', (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(0);
         expect(wishList).toEqual([]);
         done();
       });
@@ -17,8 +13,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(16);
-        expect(wishList).toEqual(allIssuesWishList);
+        expect(wishList).toMatchJsonSnapshot('all-issues-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -29,8 +24,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, { publishers: ['Image Comics'] }, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(11);
-        expect(wishList).toEqual(filteredIssuesWishList);
+        expect(wishList).toMatchJsonSnapshot('filtered-issues-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicIssue();
         });
@@ -41,8 +35,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, { sort: 'desc' }, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(16);
-        expect(wishList).toEqual(sortedIssuesWishList);
+        expect(wishList).toMatchJsonSnapshot('sorted-issues-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicIssue();
         });

--- a/test/shared/wish-list/series-list.spec.js
+++ b/test/shared/wish-list/series-list.spec.js
@@ -1,7 +1,4 @@
 const _ = require('lodash');
-const allSeriesWishList = require('./test-data/all-series-wish-list');
-const filteredSeriesWishList = require('./test-data/filtered-series-wish-list');
-const sortedSeriesWishList = require('./test-data/sorted-series-wish-list');
 
 module.exports = function (lofcg) {
   const options = { type: lofcg.types.SERIES };
@@ -12,7 +9,6 @@ module.exports = function (lofcg) {
     it('should provide no comics in wish list with an invalid user id', function (done) {
       lofcg.wishList.get('foo', options, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(0);
         expect(wishList).toEqual([]);
         done();
       });
@@ -21,8 +17,7 @@ module.exports = function (lofcg) {
     it('should provide a list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, options, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(4);
-        expect(wishList).toEqual(allSeriesWishList);
+        expect(wishList).toMatchJsonSnapshot('all-series-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -33,8 +28,7 @@ module.exports = function (lofcg) {
     it('should provide a filtered list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, filteredOptions, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(2);
-        expect(wishList).toEqual(filteredSeriesWishList);
+        expect(wishList).toMatchJsonSnapshot('filtered-series-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicSeries();
         });
@@ -45,8 +39,7 @@ module.exports = function (lofcg) {
     it('should provide a sorted list of comics from a users wish list', function (done) {
       lofcg.wishList.get(readonlyUserId, sortedOptions, (err, wishList) => {
         expect(err).toBeNull();
-        expect(wishList.length).toBe(4);
-        expect(wishList).toEqual(sortedSeriesWishList);
+        expect(wishList).toMatchJsonSnapshot('sorted-series-wish-list');
         _.each(wishList, (comic) => {
           expect(comic).toBeAComicSeries();
         });

--- a/test/utils/helper-tests.js
+++ b/test/utils/helper-tests.js
@@ -21,7 +21,6 @@ const confirmEmptyFirst = function (resource, additionalArgs, tests) {
       });
 
       it('should be empty list', function () {
-        expect(getValue.length).toBe(0);
         expect(getValue).toEqual([]);
       });
 
@@ -57,7 +56,6 @@ const testRemovingFromList = function (resource, resourceId, additionalArgs) {
     it('should be empty', function (done) {
       const callback = function (err, value) {
         expect(err).toBeNull();
-        expect(value.length).toBe(0);
         expect(value).toEqual([]);
         done();
       };


### PR DESCRIPTION
Add new matcher `toMatchJsonSnapshot` to provide basic comparison and simplify regenerating snapshot file for changes