### PR TITLE
Remove changeable user metrics from snapshots

### DIFF
--- a/test/logged-in/collection/test-data/all-issues-collection.json
+++ b/test/logged-in/collection/test-data/all-issues-collection.json
@@ -9,12 +9,6 @@
         "description": "All appears lost in the fight against the tyrannical Galactic Empire. The Rebellion has discovered the existence of the Empire’s ultimate super-weapon. The Death Star. With the power to wipe planets from existence,...",
         "releaseDate": "2017-04-05",
         "price": "$4.99",
-        "diamondSku": "FEB170948",
-        "userMetrics": {
-            "pulled": null,
-            "added": 319,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170948"
     }
 ]

--- a/test/logged-in/pull-list/test-data/all-issues-pull-list.json
+++ b/test/logged-in/pull-list/test-data/all-issues-pull-list.json
@@ -9,12 +9,6 @@
         "description": "All appears lost in the fight against the tyrannical Galactic Empire. The Rebellion has discovered the existence of the Empire’s ultimate super-weapon. The Death Star. With the power to wipe planets from existence,...",
         "releaseDate": "2017-04-05",
         "price": "$4.99",
-        "diamondSku": "FEB170948",
-        "userMetrics": {
-            "pulled": null,
-            "added": 318,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "FEB170948"
     }
 ]

--- a/test/logged-in/read-list/test-data/all-issues-read-list.json
+++ b/test/logged-in/read-list/test-data/all-issues-read-list.json
@@ -9,12 +9,6 @@
         "description": "All appears lost in the fight against the tyrannical Galactic Empire. The Rebellion has discovered the existence of the Empire’s ultimate super-weapon. The Death Star. With the power to wipe planets from existence,...",
         "releaseDate": "2017-04-05",
         "price": "$4.99",
-        "diamondSku": "FEB170948",
-        "userMetrics": {
-            "pulled": null,
-            "added": 318,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170948"
     }
 ]

--- a/test/logged-in/wish-list/test-data/all-issues-wish-list.json
+++ b/test/logged-in/wish-list/test-data/all-issues-wish-list.json
@@ -9,12 +9,6 @@
         "description": "All appears lost in the fight against the tyrannical Galactic Empire. The Rebellion has discovered the existence of the Empire’s ultimate super-weapon. The Death Star. With the power to wipe planets from existence,...",
         "releaseDate": "2017-04-05",
         "price": "$4.99",
-        "diamondSku": "FEB170948",
-        "userMetrics": {
-            "pulled": null,
-            "added": 318,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170948"
     }
 ]

--- a/test/shared/collection/test-data/all-issues-collection.json
+++ b/test/shared/collection/test-data/all-issues-collection.json
@@ -9,13 +9,7 @@
         "description": "It's Adventure Time! Join Finn the Human, Jake the Dog, and Princess Bubblegum for all-new adventures through The Land of Ooo. The top-rated Cartoon Network show now has its own comic book! With the show exploding in the...",
         "releaseDate": "2012-02-08",
         "price": "$3.99",
-        "diamondSku": "DEC110939",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC110939"
     },
     {
         "id": "9426413",
@@ -27,13 +21,7 @@
         "description": "THERE'S NO BETTER TIME TO JUMP INTO THE ALL-AGES SENSATION! Join Jake the Dog and Finn the Human as they have sensational adventures in the magical land of Ooo! If you haven't checked out the comic book adaptation...",
         "releaseDate": "2012-11-28",
         "price": "$3.99",
-        "diamondSku": "SEP120936",
-        "userMetrics": {
-            "pulled": null,
-            "added": 60,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP120936"
     },
     {
         "id": "6782447",
@@ -45,13 +33,7 @@
         "description": "THE FINAL TOTALLY AWESOME ISSUE OF THIS ADVENTURE TIME MINI-SERIES! Can the Scream Queens rock their crazy-huge biggest gig ever...and will Princess Bubblegum finally discover the true meaning of ROCK? Final issue of this...",
         "releaseDate": "2012-12-19",
         "price": "$3.99",
-        "diamondSku": "OCT120924",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT120924"
     },
     {
         "id": "7883919",
@@ -63,13 +45,7 @@
         "description": "THE HOTTEST ALL-AGES COMIC CELEBRATES ITS ONE YEAR ANNIVERSARY! BMO's sick, but it's not just any virus...it's a magical virus! And now, Finn and Jake have to seek out a sorta-no-good-very-bad wizard to set things right!...",
         "releaseDate": "2013-01-30",
         "price": "$3.99",
-        "diamondSku": "NOV120968",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV120968"
     },
     {
         "id": "5012608",
@@ -81,13 +57,7 @@
         "description": "CRITICS ARE CALLING ADVENTURE TIME THE \"BEST SERIES OF 2012!\" The latest issue of the hottest all-ages comic on the stands now! Join Finn and Jake as they work to save BMO from a magical virus...by going INSIDE...",
         "releaseDate": "2013-02-20",
         "price": "$3.99",
-        "diamondSku": "DEC120942",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC120942"
     },
     {
         "id": "5112162",
@@ -99,13 +69,7 @@
         "description": "FINAL ISSUE OF THE ARC! Finn and Jake are trapped inside a digital world...who can rescue the heroes? Find out in the latest installment of \"the best comic of 2012!\" An all-ages sensation!",
         "releaseDate": "2013-03-20",
         "price": "$3.99",
-        "diamondSku": "JAN130975",
-        "userMetrics": {
-            "pulled": null,
-            "added": 70,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN130975"
     },
     {
         "id": "4694804",
@@ -117,13 +81,7 @@
         "description": "A STAND-ALONE ISSUE LEADING INTO THE NEW ARC! A PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human in this totally topsy-turvy take on the land of Ooo! The best all-ages series of 2012 continues!...",
         "releaseDate": "2013-04-17",
         "price": "$3.99",
-        "diamondSku": "FEB130836",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB130836"
     },
     {
         "id": "6416927",
@@ -135,13 +93,7 @@
         "description": "THE FIRST ISSUE OF A NEW ARC AND THE PERFECT JUMPING-ON POINT FOR NEW READERS! It's an all-new adventure for Finn, Jake and the gang from critically acclaimed writer Ryan North! The best all-ages series of 2012 continues!",
         "releaseDate": "2013-05-22",
         "price": "$3.99",
-        "diamondSku": "MAR130943",
-        "userMetrics": {
-            "pulled": null,
-            "added": 59,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR130943"
     },
     {
         "id": "8765342",
@@ -153,13 +105,7 @@
         "description": "It's a new TOTALLY MATH adventure for Finn and Jake, everyone's favorite boy and his dog! And this time, we mean that",
         "releaseDate": "2013-06-26",
         "price": "$3.99",
-        "diamondSku": "APR130968",
-        "userMetrics": {
-            "pulled": null,
-            "added": 65,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR130968"
     },
     {
         "id": "3518528",
@@ -171,13 +117,7 @@
         "description": "The TOTALLY MATH adventure continues with Finn and Jake, everyone's favorite human and dog duo! Will the guys find a way out of their dungeon despair, or will they have to settle for hanging with some tops blooby skeleton...",
         "releaseDate": "2013-07-17",
         "price": "$3.99",
-        "diamondSku": "MAY130960",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY130960"
     },
     {
         "id": "8840442",
@@ -189,13 +129,7 @@
         "description": "The TOTALLY MATH adventure continues with Finn and Jake, everyone's favorite human and his dog! And this arc, things are getting literally mathematical for our heroes... The newest issue of the hottest allages book on...",
         "releaseDate": "2013-08-21",
         "price": "$3.99",
-        "diamondSku": "JUN130920",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN130920"
     },
     {
         "id": "5232458",
@@ -207,13 +141,7 @@
         "description": "It's Totally Mathematical! Join Finn, Jake, and all of their friends in this second issue of the ongoing comic book series showcasing all-new adventures through the magical Land of Ooo. The boys have embarked on another...",
         "releaseDate": "2012-03-14",
         "price": "$3.99",
-        "diamondSku": "JAN120971",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN120971"
     },
     {
         "id": "3124065",
@@ -225,13 +153,7 @@
         "description": "Finn and Jake have endured the Ice King's weird emotional dungeon adventure, and the fiery pits created by Marceline's dad...what will their final dungeon adventure bring? A great jumping-on point for dungeon masters...",
         "releaseDate": "2013-09-18",
         "price": "$3.99",
-        "diamondSku": "JUL130958",
-        "userMetrics": {
-            "pulled": null,
-            "added": 61,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL130958"
     },
     {
         "id": "2882322",
@@ -243,13 +165,7 @@
         "description": "It doesn't matter how many episodes or issues you get your hands on for ADVENTURE TIME, there will always be something new and amazing waiting for you behind every corner. The comic is a great read for allages and it's...",
         "releaseDate": "2013-10-16",
         "price": "$3.99",
-        "diamondSku": "AUG131132",
-        "userMetrics": {
-            "pulled": null,
-            "added": 63,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG131132"
     },
     {
         "id": "8724783",
@@ -261,13 +177,7 @@
         "description": "Finn and Jake find themselves in a sticky situation when Princess Bubblegum's experiments searching for the origin of life...specifically, her life...go horribly wrong, overcoming the Candy Kingdom! What sour weapon can...",
         "releaseDate": "2013-11-20",
         "price": "$3.99",
-        "diamondSku": "SEP131006",
-        "userMetrics": {
-            "pulled": null,
-            "added": 57,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP131006"
     },
     {
         "id": "2129061",
@@ -279,13 +189,7 @@
         "description": "Will Princess Bubblegum be able to stop her creation from spreading, or is already too late for the Kingdom of Ooo?! With the Kingdoms Heroes under it's influence it leaves Marceline and Princess Bubblegum in a race again...",
         "releaseDate": "2013-12-18",
         "price": "$3.99",
-        "diamondSku": "OCT130970",
-        "userMetrics": {
-            "pulled": null,
-            "added": 57,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT130970"
     },
     {
         "id": "6924403",
@@ -297,13 +201,7 @@
         "description": "Princess Bubblegum faces the consequences of her science experiment gone wrong as she finally finds a way to save the day! But is it too late? Find out if Princess Bubblegum is able to right all her wrongs or if her friends...",
         "releaseDate": "2014-01-15",
         "price": "$3.99",
-        "diamondSku": "NOV130913",
-        "userMetrics": {
-            "pulled": null,
-            "added": 53,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV130913"
     },
     {
         "id": "7210049",
@@ -315,13 +213,7 @@
         "description": "Ever have a favorite item? Something that you plan to keep with you always? Something that has a history back further than you can remember? Something precious...cherished...that will continue on after you've left on your...",
         "releaseDate": "2014-02-19",
         "price": "$4.99",
-        "diamondSku": "DEC130999",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC130999"
     },
     {
         "id": "8151285",
@@ -333,13 +225,7 @@
         "description": "Cover A: Mike Holmes Cover B: Craig Arndt Finn and Jake have always been best buds; they are always together, it's just something best buds do. But what happens when these two friends get separated on a crazy adventure...",
         "releaseDate": "2014-03-19",
         "price": "$3.99",
-        "diamondSku": "JAN141015",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN141015"
     },
     {
         "id": "2895692",
@@ -351,13 +237,7 @@
         "description": "This special arc with guest artist Jim Rugg continues!! Finn and Jake might have finally met their match. but what will happen with it turns out that the match isn't a match at all? Things are getting crazy in the land of...",
         "releaseDate": "2014-04-16",
         "price": "$3.99",
-        "diamondSku": "FEB141084",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB141084"
     },
     {
         "id": "7033633",
@@ -369,13 +249,7 @@
         "description": "With one answer, there is always a million questions. Finn and Jake find themselves out of one problem and into another. It looks like it's going to be a race to the finish as our heroes discover what it really means...",
         "releaseDate": "2014-05-21",
         "price": "$3.99",
-        "diamondSku": "MAR140988",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR140988"
     },
     {
         "id": "5910531",
@@ -387,13 +261,7 @@
         "description": "Finn and Jake are back in their bodies, but it looks like the damage is done. Will our heroes be able to right everything they've done or is Ooo finally lost? With the help of an unlikely source, this day might be saved....",
         "releaseDate": "2014-06-18",
         "price": "$3.99",
-        "diamondSku": "APR141004",
-        "userMetrics": {
-            "pulled": null,
-            "added": 46,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR141004"
     },
     {
         "id": "3714650",
@@ -405,13 +273,7 @@
         "description": "Algebraic! Don't miss Finn, Jake, and all of their friends on their biggest adventure yet! Trapped by the dreaded Lich, the guys gotta stop all of Ooo from being sucked away forever - and rescue a bunch of wayward Princesses....",
         "releaseDate": "2012-04-11",
         "price": "$3.99",
-        "diamondSku": "FEB120869",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB120869"
     },
     {
         "id": "2730049",
@@ -423,13 +285,7 @@
         "description": "It's a rad stand-alone ZINE Special! Enjoy this crazy special as the citizens of Ooo create their own zines to share. Marceline has a lot to say about her music, Peppermint Butler has a few life tips for anyone who will...",
         "releaseDate": "2014-07-16",
         "price": "$3.99",
-        "diamondSku": "MAY141187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY141187"
     },
     {
         "id": "4699308",
@@ -441,13 +297,7 @@
         "description": "When Princess Bubblegum and Marceline get their driver’s licenses, they have the perfect plan—build a giant ramp and drive off of it! It’s gonna be so much fun…wait, who’s the Mnemonoid, and...",
         "releaseDate": "2014-08-20",
         "price": "$3.99",
-        "diamondSku": "JUN140983",
-        "userMetrics": {
-            "pulled": null,
-            "added": 62,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN140983"
     },
     {
         "id": "7201061",
@@ -459,13 +309,7 @@
         "description": "Finn is on an impossible mission to break Mnemonoid’s curse so that he can finally live his life…and remember it! It’s going to take a lot of pal time and a lot of help from the best of friends but this...",
         "releaseDate": "2014-10-01",
         "price": "$3.99",
-        "diamondSku": "JUL141004",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL141004"
     },
     {
         "id": "2543079",
@@ -477,13 +321,7 @@
         "description": "Magic Man's hold on Finn is proving to be stronger than anyone had thought and it's taking the whole crew to band together to help their friend, only this time, there really might be nothing they can do. It's...",
         "releaseDate": "2014-10-29",
         "price": "$3.99",
-        "diamondSku": "AUG141192",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG141192"
     },
     {
         "id": "4348530",
@@ -495,13 +333,7 @@
         "description": "Finn has made it to Magic Man at last! It's time for this adventure to end and for Finn to finally get his memory back. It might seem like an easy end, but it looks like there is still one more trick up Magic Man's sleeve.",
         "releaseDate": "2014-12-03",
         "price": "$3.99",
-        "diamondSku": "SEP141181",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP141181"
     },
     {
         "id": "8276925",
@@ -513,13 +345,7 @@
         "description": "It's the end of an era...the last ADVENTURE TIME issue featuring the Eisner Awardteam of Ryan North, Shelli Paroline, and Braden Lamb. It's your chance to say goodbye, and experience an adventure you'll never forget.",
         "releaseDate": "2014-12-24",
         "price": "$3.99",
-        "diamondSku": "OCT141197",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT141197"
     },
     {
         "id": "4821132",
@@ -531,13 +357,7 @@
         "description": "It's the first Adventure Time starring its new creative team! With indie all-star Chris Hastings writing and the amazingly talented Zachary Sterling on art, these mathematical adventures are only going to get more algebraic!...",
         "releaseDate": "2015-01-28",
         "price": "$3.99",
-        "diamondSku": "NOV141132",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV141132"
     },
     {
         "id": "2724168",
@@ -549,13 +369,7 @@
         "description": "Finn and Jake might have finally met their match in the EPIC THUMB WAR COMPETITION FOR BAKED GOODS, but it looks like their battle is just beginning as these two pals get ready for their biggest challenge yet.",
         "releaseDate": "2015-02-25",
         "price": "$3.99",
-        "diamondSku": "DEC141239",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC141239"
     },
     {
         "id": "1233990",
@@ -567,13 +381,7 @@
         "description": "Everyone is hungry, but there isn't enough food to go around. Things get a little dicey as Finn and Jake try to figure out what is up with their friends, and why does this little witch keep coming back? Glob, she's really...",
         "releaseDate": "2015-03-25",
         "price": "$3.99",
-        "diamondSku": "JAN151187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 45,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN151187"
     },
     {
         "id": "3199536",
@@ -585,13 +393,7 @@
         "description": "The entire world of Ooo is not able to cook but Jake comes through and saves the day with his sandwiches. It's not over yet, though, as the witch is gonna summon her ultimate monster baddie.",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB151188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB151188"
     },
     {
         "id": "5195551",
@@ -603,13 +405,7 @@
         "description": "Oh My Glob! The Latest Super-Cool Issue of the Hit Series! Finn, Jake, Marceline, Princess Bubblegum and even Lumpy Space Princess have banded together to stop that jerk the Lich from throwing all of Ooo into the sun! It's...",
         "releaseDate": "2012-05-16",
         "price": "$3.99",
-        "diamondSku": "MAR120884",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR120884"
     },
     {
         "id": "4343201",
@@ -621,13 +417,7 @@
         "description": "It's a special interactive, one-shot issue! Magic Man plans to use the reader to help beat Finn and Jake, but can our heroes turn the tables? Features a special short written by debut writer Henry Leo and Matt Fraction (Hawkeye)!",
         "releaseDate": "2015-05-27",
         "price": "$3.99",
-        "diamondSku": "MAR151093",
-        "userMetrics": {
-            "pulled": null,
-            "added": 45,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR151093"
     },
     {
         "id": "3374523",
@@ -639,13 +429,7 @@
         "description": "New story arc! Peppermint Butler is one of the most mysterious dudes in Ooo. When he approaches Finn and Jake to recruit them for the secret agency he runs, they've just gotta join and see what's going on!",
         "releaseDate": "2015-06-24",
         "price": "$3.99",
-        "diamondSku": "APR151254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR151254"
     },
     {
         "id": "3708126",
@@ -657,13 +441,7 @@
         "description": "Finn and Jake are on the run, trying to figure out who on the inside framed them for the destruction of Peppermint Butler's secret security team.",
         "releaseDate": "2015-07-22",
         "price": "$3.99",
-        "diamondSku": "MAY151155",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY151155"
     },
     {
         "id": "3672337",
@@ -675,13 +453,7 @@
         "description": "Finn and Jake break into Party God's yacht to try and clear their names!",
         "releaseDate": "2015-08-26",
         "price": "$3.99",
-        "diamondSku": "JUN151150",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN151150"
     },
     {
         "id": "2522194",
@@ -693,13 +465,7 @@
         "description": "Finn and Jake are pretty sure the King of Ooo's big conference is a trap and have to sneak in to stop it!",
         "releaseDate": "2015-09-23",
         "price": "$3.99",
-        "diamondSku": "JUL151140",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL151140"
     },
     {
         "id": "2106538",
@@ -711,13 +477,7 @@
         "description": "Special one-shot issue! Princess Bubblegum needs Lemongrab's help, but that means she needs to do things his way for once.",
         "releaseDate": "2015-10-14",
         "price": "$3.99",
-        "diamondSku": "AUG151256",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG151256"
     },
     {
         "id": "6610160",
@@ -729,13 +489,7 @@
         "description": "When one of Joshua's old spells wears off, Finn and Jake find themselves facing an old childhood friend that neither of them can remember!",
         "releaseDate": "2015-11-11",
         "price": "$3.99",
-        "diamondSku": "SEP151156",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP151156"
     },
     {
         "id": "7736591",
@@ -747,13 +501,7 @@
         "description": "Finn, Jake, and their mysterious “old friend” travel to Jake’s parents’ old apartment in the city to figure out what’s going on!",
         "releaseDate": "2015-12-09",
         "price": "$3.99",
-        "diamondSku": "OCT151261",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT151261"
     },
     {
         "id": "8837436",
@@ -765,13 +513,7 @@
         "description": "Finn and Jake learn the truth about their mysterious old friend and his connection to Joshua’s spell.",
         "releaseDate": "2016-01-13",
         "price": "$3.99",
-        "diamondSku": "NOV151191",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV151191"
     },
     {
         "id": "3076848",
@@ -783,13 +525,7 @@
         "description": "Finn and Jake must re-banish their old friend from reality in order to defeat a monstrous threat.",
         "releaseDate": "2016-02-10",
         "price": "$3.99",
-        "diamondSku": "DEC151157",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC151157"
     },
     {
         "id": "7381906",
@@ -801,13 +537,7 @@
         "description": "Don't miss the beginning of the new arc of this totally rhombus series! The totally sick gang of Finn, Jake, Marceline, Princess Bubblegum, and the Ice King are back in this new arc of the incredibly popular all-ages...",
         "releaseDate": "2012-06-20",
         "price": "$3.99",
-        "diamondSku": "APR120950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR120950"
     },
     {
         "id": "8363231",
@@ -819,13 +549,7 @@
         "description": "Fourth anniversary issue! This special oversized one-shot issue introduces new series artist Ian McGinty (Welcome to Showside, Bravest Warriors)! Finn takes a tour of his past lives when he astral projects through an old...",
         "releaseDate": "2016-03-09",
         "price": "$4.99",
-        "diamondSku": "JAN161198",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN161198"
     },
     {
         "id": "6435163",
@@ -837,13 +561,7 @@
         "description": "After too many back-to-back quests, Jake and Finn disagree on how important doing this hero stuff really is.",
         "releaseDate": "2016-04-13",
         "price": "$3.99",
-        "diamondSku": "FEB161263",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB161263"
     },
     {
         "id": "3246610",
@@ -855,13 +573,7 @@
         "description": "In the ghost realm, Jake is met with some pretty familiar challenges to overcome.",
         "releaseDate": "2016-05-11",
         "price": "$3.99",
-        "diamondSku": "MAR161238",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR161238"
     },
     {
         "id": "5354669",
@@ -873,13 +585,7 @@
         "description": "Jake successfully fools King Ghost of the ghost realm and must escape with the cure for Finn, but could this have been a ruse all along to teach Jake a lesson?",
         "releaseDate": "2016-06-08",
         "price": "$3.99",
-        "diamondSku": "APR161420",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR161420"
     },
     {
         "id": "7072449",
@@ -891,13 +597,7 @@
         "description": "Finn and Jake are sheriff and deputy of a wild west town...or are they? Is this even real?!",
         "releaseDate": "2016-07-13",
         "price": "$3.99",
-        "diamondSku": "MAY161295",
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY161295"
     },
     {
         "id": "5074403",
@@ -909,13 +609,7 @@
         "description": "Finn and Jake discover that it's not just them-everyone in Ooo is trapped in their own little realities!",
         "releaseDate": "2016-08-10",
         "price": "$3.99",
-        "diamondSku": "JUN161298",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN161298"
     },
     {
         "id": "3389427",
@@ -927,13 +621,7 @@
         "description": "Finn and Jake look for BMO in order to break free of the fantasies they're trapped in!",
         "releaseDate": "2016-09-14",
         "price": "$3.99",
-        "diamondSku": "JUL161400",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL161400"
     },
     {
         "id": "3049657",
@@ -945,13 +633,7 @@
         "description": "Finn and Jake make it to the core of BMOWORLD and confront the real culprit behind this mess!",
         "releaseDate": "2016-10-12",
         "price": "$3.99",
-        "diamondSku": "AUG161394",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG161394"
     },
     {
         "id": "7801919",
@@ -963,13 +645,7 @@
         "description": "Finn decides to become a dungeon master like his father figure Joshua was!",
         "releaseDate": "2016-11-09",
         "price": "$3.99",
-        "diamondSku": "SEP161456",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161456"
     },
     {
         "id": "9517783",
@@ -981,13 +657,7 @@
         "description": "Finn finds his current adventure to be a bit more than he expected, but he's getting really into it. It's kind of like how someone approaches taking over their basement with a model train set.",
         "releaseDate": "2016-12-07",
         "price": "$3.99",
-        "diamondSku": "OCT161333",
-        "userMetrics": {
-            "pulled": null,
-            "added": 25,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT161333"
     },
     {
         "id": "2705608",
@@ -999,13 +669,7 @@
         "description": "THE FUN WILL NEVER END IN THIS HOT ALL-AGES SERIES! The awesome adventures of Finn, Jake, Marceline, Princess Bubblegum and the Ice King continue in the latest issue of this critically-acclaimed, on-going series! Demand...",
         "releaseDate": "2012-07-18",
         "price": "$3.99",
-        "diamondSku": "MAY120994",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY120994"
     },
     {
         "id": "8903990",
@@ -1017,13 +681,7 @@
         "description": "Finn gets into the dungeon-making scene and meets fellow dungeon masters, some of whom are villains from Finn's past!",
         "releaseDate": "2017-01-04",
         "price": "$3.99",
-        "diamondSku": "NOV161284",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV161284"
     },
     {
         "id": "4168107",
@@ -1035,13 +693,7 @@
         "description": "Finn becomes a bit obsessed with building his perfect dungeon, losing the plot a bit, and toys with terrible and great evil forces to build his ideal dungeon understand Joshua better through dungeoncraft.",
         "releaseDate": "2017-02-01",
         "price": "$3.99",
-        "diamondSku": "DEC161434",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC161434"
     },
     {
         "id": "6562940",
@@ -1053,13 +705,7 @@
         "description": "A contest is started to see who is the best Princess in all of Ooo!",
         "releaseDate": "2017-03-01",
         "price": "$3.99",
-        "diamondSku": "JAN171486",
-        "userMetrics": {
-            "pulled": null,
-            "added": 24,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN171486"
     },
     {
         "id": "5428363",
@@ -1071,13 +717,7 @@
         "description": "The Princess competition continues with everyone trying to do their best despite the prankster trying to ruin their fun.",
         "releaseDate": "2017-04-05",
         "price": "$3.99",
-        "diamondSku": "FEB171363",
-        "userMetrics": {
-            "pulled": null,
-            "added": 29,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB171363"
     },
     {
         "id": "1205249",
@@ -1089,13 +729,7 @@
         "description": "JOIN JAKE THE DOG AND FINN THE HUMAN AS THE HOTTEST ALL-AGES COMIC BOOK ON THE STANDS CONTINUES! The totally mathematical adventure continues in this latest time-bending issue of ADVENTURE TIME! Order early -- issue #1 went...",
         "releaseDate": "2012-08-22",
         "price": "$3.99",
-        "diamondSku": "JUN120949",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN120949"
     },
     {
         "id": "6538129",
@@ -1107,13 +741,7 @@
         "description": "THE MOST POPULAR AND TOTALLY RHOMBUS ALL-AGES COMIC ON THE STANDS TODAY! Join Jake the Dog and Finn the Human in another awesome issue of this all-ages classic! With Ooo in the grips of a Jake-caused time paradox, there's...",
         "releaseDate": "2012-09-26",
         "price": "$3.99",
-        "diamondSku": "JUL120908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL120908"
     },
     {
         "id": "2494536",
@@ -1125,13 +753,7 @@
         "description": "BRAND-NEW STORY ARC! PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human as they try to right the wrongs of a Jake-caused TIME PARADOX! If you haven't checked out the comic book adaptation of the...",
         "releaseDate": "2012-10-24",
         "price": "$3.99",
-        "diamondSku": "AUG120938",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG120938"
     },
     {
         "id": "8361841",
@@ -1143,13 +765,7 @@
         "description": "THE FUN WILL NEVER END IN THIS SPECIAL EXPANDED ADVENTURE TIME ANNUAL! Featuring some of the hottest talent in comics today putting their creative spin on the land of Ooo! A great tool for bringing readers into the series...",
         "releaseDate": "2013-05-29",
         "price": "$4.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "9733561",
@@ -1161,13 +777,7 @@
         "description": "WHY WE LOVE IT: A very special issue by dynamite creators Becky Dreistdat and Frank Gibson bring you the cutest thing imaginable...Baby Fionna and Cake! WHY YOU'LL LOVE IT: Not only does this issue feature fully painted...",
         "releaseDate": "2014-04-30",
         "price": "$4.99",
-        "diamondSku": "FEB141087",
-        "userMetrics": {
-            "pulled": null,
-            "added": 53,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB141087"
     },
     {
         "id": "1094288",
@@ -1179,13 +789,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "5900157",
@@ -1197,13 +801,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "5996813",
@@ -1215,13 +813,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "8972309",
@@ -1233,13 +825,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "8471271",
@@ -1251,13 +837,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "5947148",
@@ -1269,13 +849,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8137536",
@@ -1287,13 +861,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "3173369",
@@ -1305,13 +873,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "1462701",
@@ -1323,13 +885,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "2519140",
@@ -1341,13 +897,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "3429543",
@@ -1359,13 +909,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "9240446",
@@ -1377,13 +921,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "4148513",
@@ -1395,13 +933,7 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     },
     {
         "id": "8374448",
@@ -1413,13 +945,7 @@
         "description": "Wolverine, Deadpool, Doctor Doom, Thanos: There's one hero that's beaten them all-and now she's got her own ongoing series! (Not that she's bragging.) That's right, you asked for it, you got it, it's...",
         "releaseDate": "2015-01-07",
         "price": "$3.99",
-        "diamondSku": "NOV140732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 437,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140732"
     },
     {
         "id": "6677681",
@@ -1431,13 +957,7 @@
         "description": "Starting college is hard enough, but now Squirrel Girl has to deal with Galactus too? The fate of the entire planet hangs in the balance, and only Squirrel Girl can save it! Also, her squirrel friend Tippy Toe. She can help...",
         "releaseDate": "2015-02-04",
         "price": "$3.99",
-        "diamondSku": "DEC140883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 391,
-            "consensusVote": 81,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140883"
     },
     {
         "id": "2790619",
@@ -1449,13 +969,7 @@
         "description": "Time is running out, and the only way for Squirrel Girl to stop Galactus is to get to the moon... you know, somehow?? See the unveiling of Squirrel Girl's new Flying Squirrel Suit... that she maaaaybe borrowed from Iron...",
         "releaseDate": "2015-03-18",
         "price": "$3.99",
-        "diamondSku": "JAN150832",
-        "userMetrics": {
-            "pulled": null,
-            "added": 355,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150832"
     },
     {
         "id": "4859051",
@@ -1467,13 +981,7 @@
         "description": "The final showdown between Galactus and Squirrel Girl is here! It's the Power Cosmic versus the Power Chestnut: WHO WILL WIN? Also, Squirrel Girl is late for class. So there's TWO disasters coming!!",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB150779",
-        "userMetrics": {
-            "pulled": null,
-            "added": 358,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150779"
     },
     {
         "id": "8229407",
@@ -1485,13 +993,7 @@
         "description": "The breakout character of 2015 continues her one-woman crusade against injustice and jerks in this standalone issue, a perfect jumping-on point for new readers! These TAILS of the Squirrel Girl will show you the Marvel Universe's...",
         "releaseDate": "2015-05-06",
         "price": "$3.99",
-        "diamondSku": "MAR150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 336,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR150721"
     },
     {
         "id": "9824471",
@@ -1503,13 +1005,7 @@
         "description": "The start of a new arc! Squirrel Girl meets some potential new allies, including... GIRL SQUIRREL?? I don't know why we put question marks there; it's actually what happens! Also a hippo named 'Hippo' is...",
         "releaseDate": "2015-06-03",
         "price": "$3.99",
-        "diamondSku": "APR150890",
-        "userMetrics": {
-            "pulled": null,
-            "added": 331,
-            "consensusVote": 87,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR150890"
     },
     {
         "id": "5061237",
@@ -1521,13 +1017,7 @@
         "description": "Our friend Squirrel Girl doesn't like our new friend Girl Squirrel! In this issue we'll discover if this dislike is... POTENTIALLY JUSTIFIED?? Also: if you don't care whether or not these two people like each...",
         "releaseDate": "2015-07-01",
         "price": "$3.99",
-        "diamondSku": "MAY150794",
-        "userMetrics": {
-            "pulled": null,
-            "added": 322,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY150794"
     },
     {
         "id": "5724529",
@@ -1539,12 +1029,6 @@
         "description": "It's the classic tale of good (squirrel) versus evil (squirrel) as SQUIRREL GIRL fights RATATOSKR, the Norse Squirrel God!  The fate of the world hangs in the balance! And yes, \"Norse Squirrel God\"...",
         "releaseDate": "2015-08-12",
         "price": "$3.99",
-        "diamondSku": "JUN150808",
-        "userMetrics": {
-            "pulled": null,
-            "added": 306,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN150808"
     }
 ]

--- a/test/shared/collection/test-data/filtered-issues-collection.json
+++ b/test/shared/collection/test-data/filtered-issues-collection.json
@@ -9,13 +9,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "5900157",
@@ -27,13 +21,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "5996813",
@@ -45,13 +33,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "8972309",
@@ -63,13 +45,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "8471271",
@@ -81,13 +57,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "5947148",
@@ -99,13 +69,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8137536",
@@ -117,13 +81,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "3173369",
@@ -135,13 +93,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "1462701",
@@ -153,13 +105,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "2519140",
@@ -171,13 +117,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "3429543",
@@ -189,13 +129,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "9240446",
@@ -207,13 +141,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "4148513",
@@ -225,12 +153,6 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     }
 ]

--- a/test/shared/collection/test-data/sorted-issues-collection.json
+++ b/test/shared/collection/test-data/sorted-issues-collection.json
@@ -9,13 +9,7 @@
         "description": "It's the classic tale of good (squirrel) versus evil (squirrel) as SQUIRREL GIRL fights RATATOSKR, the Norse Squirrel God!  The fate of the world hangs in the balance! And yes, \"Norse Squirrel God\"...",
         "releaseDate": "2015-08-12",
         "price": "$3.99",
-        "diamondSku": "JUN150808",
-        "userMetrics": {
-            "pulled": null,
-            "added": 306,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN150808"
     },
     {
         "id": "5061237",
@@ -27,13 +21,7 @@
         "description": "Our friend Squirrel Girl doesn't like our new friend Girl Squirrel! In this issue we'll discover if this dislike is... POTENTIALLY JUSTIFIED?? Also: if you don't care whether or not these two people like each...",
         "releaseDate": "2015-07-01",
         "price": "$3.99",
-        "diamondSku": "MAY150794",
-        "userMetrics": {
-            "pulled": null,
-            "added": 322,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY150794"
     },
     {
         "id": "9824471",
@@ -45,13 +33,7 @@
         "description": "The start of a new arc! Squirrel Girl meets some potential new allies, including... GIRL SQUIRREL?? I don't know why we put question marks there; it's actually what happens! Also a hippo named 'Hippo' is...",
         "releaseDate": "2015-06-03",
         "price": "$3.99",
-        "diamondSku": "APR150890",
-        "userMetrics": {
-            "pulled": null,
-            "added": 331,
-            "consensusVote": 87,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR150890"
     },
     {
         "id": "8229407",
@@ -63,13 +45,7 @@
         "description": "The breakout character of 2015 continues her one-woman crusade against injustice and jerks in this standalone issue, a perfect jumping-on point for new readers! These TAILS of the Squirrel Girl will show you the Marvel Universe's...",
         "releaseDate": "2015-05-06",
         "price": "$3.99",
-        "diamondSku": "MAR150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 336,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR150721"
     },
     {
         "id": "4859051",
@@ -81,13 +57,7 @@
         "description": "The final showdown between Galactus and Squirrel Girl is here! It's the Power Cosmic versus the Power Chestnut: WHO WILL WIN? Also, Squirrel Girl is late for class. So there's TWO disasters coming!!",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB150779",
-        "userMetrics": {
-            "pulled": null,
-            "added": 358,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150779"
     },
     {
         "id": "2790619",
@@ -99,13 +69,7 @@
         "description": "Time is running out, and the only way for Squirrel Girl to stop Galactus is to get to the moon... you know, somehow?? See the unveiling of Squirrel Girl's new Flying Squirrel Suit... that she maaaaybe borrowed from Iron...",
         "releaseDate": "2015-03-18",
         "price": "$3.99",
-        "diamondSku": "JAN150832",
-        "userMetrics": {
-            "pulled": null,
-            "added": 355,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150832"
     },
     {
         "id": "6677681",
@@ -117,13 +81,7 @@
         "description": "Starting college is hard enough, but now Squirrel Girl has to deal with Galactus too? The fate of the entire planet hangs in the balance, and only Squirrel Girl can save it! Also, her squirrel friend Tippy Toe. She can help...",
         "releaseDate": "2015-02-04",
         "price": "$3.99",
-        "diamondSku": "DEC140883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 391,
-            "consensusVote": 81,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140883"
     },
     {
         "id": "8374448",
@@ -135,13 +93,7 @@
         "description": "Wolverine, Deadpool, Doctor Doom, Thanos: There's one hero that's beaten them all-and now she's got her own ongoing series! (Not that she's bragging.) That's right, you asked for it, you got it, it's...",
         "releaseDate": "2015-01-07",
         "price": "$3.99",
-        "diamondSku": "NOV140732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 437,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140732"
     },
     {
         "id": "4148513",
@@ -153,13 +105,7 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     },
     {
         "id": "9240446",
@@ -171,13 +117,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "3429543",
@@ -189,13 +129,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "2519140",
@@ -207,13 +141,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "1462701",
@@ -225,13 +153,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "3173369",
@@ -243,13 +165,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "8137536",
@@ -261,13 +177,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "5947148",
@@ -279,13 +189,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8471271",
@@ -297,13 +201,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "8972309",
@@ -315,13 +213,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "5996813",
@@ -333,13 +225,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "5900157",
@@ -351,13 +237,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "1094288",
@@ -369,13 +249,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "9733561",
@@ -387,13 +261,7 @@
         "description": "WHY WE LOVE IT: A very special issue by dynamite creators Becky Dreistdat and Frank Gibson bring you the cutest thing imaginable...Baby Fionna and Cake! WHY YOU'LL LOVE IT: Not only does this issue feature fully painted...",
         "releaseDate": "2014-04-30",
         "price": "$4.99",
-        "diamondSku": "FEB141087",
-        "userMetrics": {
-            "pulled": null,
-            "added": 53,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB141087"
     },
     {
         "id": "8361841",
@@ -405,13 +273,7 @@
         "description": "THE FUN WILL NEVER END IN THIS SPECIAL EXPANDED ADVENTURE TIME ANNUAL! Featuring some of the hottest talent in comics today putting their creative spin on the land of Ooo! A great tool for bringing readers into the series...",
         "releaseDate": "2013-05-29",
         "price": "$4.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "2494536",
@@ -423,13 +285,7 @@
         "description": "BRAND-NEW STORY ARC! PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human as they try to right the wrongs of a Jake-caused TIME PARADOX! If you haven't checked out the comic book adaptation of the...",
         "releaseDate": "2012-10-24",
         "price": "$3.99",
-        "diamondSku": "AUG120938",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG120938"
     },
     {
         "id": "6538129",
@@ -441,13 +297,7 @@
         "description": "THE MOST POPULAR AND TOTALLY RHOMBUS ALL-AGES COMIC ON THE STANDS TODAY! Join Jake the Dog and Finn the Human in another awesome issue of this all-ages classic! With Ooo in the grips of a Jake-caused time paradox, there's...",
         "releaseDate": "2012-09-26",
         "price": "$3.99",
-        "diamondSku": "JUL120908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL120908"
     },
     {
         "id": "1205249",
@@ -459,13 +309,7 @@
         "description": "JOIN JAKE THE DOG AND FINN THE HUMAN AS THE HOTTEST ALL-AGES COMIC BOOK ON THE STANDS CONTINUES! The totally mathematical adventure continues in this latest time-bending issue of ADVENTURE TIME! Order early -- issue #1 went...",
         "releaseDate": "2012-08-22",
         "price": "$3.99",
-        "diamondSku": "JUN120949",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN120949"
     },
     {
         "id": "5428363",
@@ -477,13 +321,7 @@
         "description": "The Princess competition continues with everyone trying to do their best despite the prankster trying to ruin their fun.",
         "releaseDate": "2017-04-05",
         "price": "$3.99",
-        "diamondSku": "FEB171363",
-        "userMetrics": {
-            "pulled": null,
-            "added": 29,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB171363"
     },
     {
         "id": "6562940",
@@ -495,13 +333,7 @@
         "description": "A contest is started to see who is the best Princess in all of Ooo!",
         "releaseDate": "2017-03-01",
         "price": "$3.99",
-        "diamondSku": "JAN171486",
-        "userMetrics": {
-            "pulled": null,
-            "added": 24,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN171486"
     },
     {
         "id": "4168107",
@@ -513,13 +345,7 @@
         "description": "Finn becomes a bit obsessed with building his perfect dungeon, losing the plot a bit, and toys with terrible and great evil forces to build his ideal dungeon understand Joshua better through dungeoncraft.",
         "releaseDate": "2017-02-01",
         "price": "$3.99",
-        "diamondSku": "DEC161434",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC161434"
     },
     {
         "id": "8903990",
@@ -531,13 +357,7 @@
         "description": "Finn gets into the dungeon-making scene and meets fellow dungeon masters, some of whom are villains from Finn's past!",
         "releaseDate": "2017-01-04",
         "price": "$3.99",
-        "diamondSku": "NOV161284",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV161284"
     },
     {
         "id": "2705608",
@@ -549,13 +369,7 @@
         "description": "THE FUN WILL NEVER END IN THIS HOT ALL-AGES SERIES! The awesome adventures of Finn, Jake, Marceline, Princess Bubblegum and the Ice King continue in the latest issue of this critically-acclaimed, on-going series! Demand...",
         "releaseDate": "2012-07-18",
         "price": "$3.99",
-        "diamondSku": "MAY120994",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY120994"
     },
     {
         "id": "9517783",
@@ -567,13 +381,7 @@
         "description": "Finn finds his current adventure to be a bit more than he expected, but he's getting really into it. It's kind of like how someone approaches taking over their basement with a model train set.",
         "releaseDate": "2016-12-07",
         "price": "$3.99",
-        "diamondSku": "OCT161333",
-        "userMetrics": {
-            "pulled": null,
-            "added": 25,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT161333"
     },
     {
         "id": "7801919",
@@ -585,13 +393,7 @@
         "description": "Finn decides to become a dungeon master like his father figure Joshua was!",
         "releaseDate": "2016-11-09",
         "price": "$3.99",
-        "diamondSku": "SEP161456",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161456"
     },
     {
         "id": "3049657",
@@ -603,13 +405,7 @@
         "description": "Finn and Jake make it to the core of BMOWORLD and confront the real culprit behind this mess!",
         "releaseDate": "2016-10-12",
         "price": "$3.99",
-        "diamondSku": "AUG161394",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG161394"
     },
     {
         "id": "3389427",
@@ -621,13 +417,7 @@
         "description": "Finn and Jake look for BMO in order to break free of the fantasies they're trapped in!",
         "releaseDate": "2016-09-14",
         "price": "$3.99",
-        "diamondSku": "JUL161400",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL161400"
     },
     {
         "id": "5074403",
@@ -639,13 +429,7 @@
         "description": "Finn and Jake discover that it's not just them-everyone in Ooo is trapped in their own little realities!",
         "releaseDate": "2016-08-10",
         "price": "$3.99",
-        "diamondSku": "JUN161298",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN161298"
     },
     {
         "id": "7072449",
@@ -657,13 +441,7 @@
         "description": "Finn and Jake are sheriff and deputy of a wild west town...or are they? Is this even real?!",
         "releaseDate": "2016-07-13",
         "price": "$3.99",
-        "diamondSku": "MAY161295",
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY161295"
     },
     {
         "id": "5354669",
@@ -675,13 +453,7 @@
         "description": "Jake successfully fools King Ghost of the ghost realm and must escape with the cure for Finn, but could this have been a ruse all along to teach Jake a lesson?",
         "releaseDate": "2016-06-08",
         "price": "$3.99",
-        "diamondSku": "APR161420",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR161420"
     },
     {
         "id": "3246610",
@@ -693,13 +465,7 @@
         "description": "In the ghost realm, Jake is met with some pretty familiar challenges to overcome.",
         "releaseDate": "2016-05-11",
         "price": "$3.99",
-        "diamondSku": "MAR161238",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR161238"
     },
     {
         "id": "6435163",
@@ -711,13 +477,7 @@
         "description": "After too many back-to-back quests, Jake and Finn disagree on how important doing this hero stuff really is.",
         "releaseDate": "2016-04-13",
         "price": "$3.99",
-        "diamondSku": "FEB161263",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB161263"
     },
     {
         "id": "8363231",
@@ -729,13 +489,7 @@
         "description": "Fourth anniversary issue! This special oversized one-shot issue introduces new series artist Ian McGinty (Welcome to Showside, Bravest Warriors)! Finn takes a tour of his past lives when he astral projects through an old...",
         "releaseDate": "2016-03-09",
         "price": "$4.99",
-        "diamondSku": "JAN161198",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN161198"
     },
     {
         "id": "7381906",
@@ -747,13 +501,7 @@
         "description": "Don't miss the beginning of the new arc of this totally rhombus series! The totally sick gang of Finn, Jake, Marceline, Princess Bubblegum, and the Ice King are back in this new arc of the incredibly popular all-ages...",
         "releaseDate": "2012-06-20",
         "price": "$3.99",
-        "diamondSku": "APR120950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR120950"
     },
     {
         "id": "3076848",
@@ -765,13 +513,7 @@
         "description": "Finn and Jake must re-banish their old friend from reality in order to defeat a monstrous threat.",
         "releaseDate": "2016-02-10",
         "price": "$3.99",
-        "diamondSku": "DEC151157",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC151157"
     },
     {
         "id": "8837436",
@@ -783,13 +525,7 @@
         "description": "Finn and Jake learn the truth about their mysterious old friend and his connection to Joshua’s spell.",
         "releaseDate": "2016-01-13",
         "price": "$3.99",
-        "diamondSku": "NOV151191",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV151191"
     },
     {
         "id": "7736591",
@@ -801,13 +537,7 @@
         "description": "Finn, Jake, and their mysterious “old friend” travel to Jake’s parents’ old apartment in the city to figure out what’s going on!",
         "releaseDate": "2015-12-09",
         "price": "$3.99",
-        "diamondSku": "OCT151261",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT151261"
     },
     {
         "id": "6610160",
@@ -819,13 +549,7 @@
         "description": "When one of Joshua's old spells wears off, Finn and Jake find themselves facing an old childhood friend that neither of them can remember!",
         "releaseDate": "2015-11-11",
         "price": "$3.99",
-        "diamondSku": "SEP151156",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP151156"
     },
     {
         "id": "2106538",
@@ -837,13 +561,7 @@
         "description": "Special one-shot issue! Princess Bubblegum needs Lemongrab's help, but that means she needs to do things his way for once.",
         "releaseDate": "2015-10-14",
         "price": "$3.99",
-        "diamondSku": "AUG151256",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG151256"
     },
     {
         "id": "2522194",
@@ -855,13 +573,7 @@
         "description": "Finn and Jake are pretty sure the King of Ooo's big conference is a trap and have to sneak in to stop it!",
         "releaseDate": "2015-09-23",
         "price": "$3.99",
-        "diamondSku": "JUL151140",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL151140"
     },
     {
         "id": "3672337",
@@ -873,13 +585,7 @@
         "description": "Finn and Jake break into Party God's yacht to try and clear their names!",
         "releaseDate": "2015-08-26",
         "price": "$3.99",
-        "diamondSku": "JUN151150",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN151150"
     },
     {
         "id": "3708126",
@@ -891,13 +597,7 @@
         "description": "Finn and Jake are on the run, trying to figure out who on the inside framed them for the destruction of Peppermint Butler's secret security team.",
         "releaseDate": "2015-07-22",
         "price": "$3.99",
-        "diamondSku": "MAY151155",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY151155"
     },
     {
         "id": "3374523",
@@ -909,13 +609,7 @@
         "description": "New story arc! Peppermint Butler is one of the most mysterious dudes in Ooo. When he approaches Finn and Jake to recruit them for the secret agency he runs, they've just gotta join and see what's going on!",
         "releaseDate": "2015-06-24",
         "price": "$3.99",
-        "diamondSku": "APR151254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR151254"
     },
     {
         "id": "4343201",
@@ -927,13 +621,7 @@
         "description": "It's a special interactive, one-shot issue! Magic Man plans to use the reader to help beat Finn and Jake, but can our heroes turn the tables? Features a special short written by debut writer Henry Leo and Matt Fraction (Hawkeye)!",
         "releaseDate": "2015-05-27",
         "price": "$3.99",
-        "diamondSku": "MAR151093",
-        "userMetrics": {
-            "pulled": null,
-            "added": 45,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR151093"
     },
     {
         "id": "5195551",
@@ -945,13 +633,7 @@
         "description": "Oh My Glob! The Latest Super-Cool Issue of the Hit Series! Finn, Jake, Marceline, Princess Bubblegum and even Lumpy Space Princess have banded together to stop that jerk the Lich from throwing all of Ooo into the sun! It's...",
         "releaseDate": "2012-05-16",
         "price": "$3.99",
-        "diamondSku": "MAR120884",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR120884"
     },
     {
         "id": "3199536",
@@ -963,13 +645,7 @@
         "description": "The entire world of Ooo is not able to cook but Jake comes through and saves the day with his sandwiches. It's not over yet, though, as the witch is gonna summon her ultimate monster baddie.",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB151188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB151188"
     },
     {
         "id": "1233990",
@@ -981,13 +657,7 @@
         "description": "Everyone is hungry, but there isn't enough food to go around. Things get a little dicey as Finn and Jake try to figure out what is up with their friends, and why does this little witch keep coming back? Glob, she's really...",
         "releaseDate": "2015-03-25",
         "price": "$3.99",
-        "diamondSku": "JAN151187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 45,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN151187"
     },
     {
         "id": "2724168",
@@ -999,13 +669,7 @@
         "description": "Finn and Jake might have finally met their match in the EPIC THUMB WAR COMPETITION FOR BAKED GOODS, but it looks like their battle is just beginning as these two pals get ready for their biggest challenge yet.",
         "releaseDate": "2015-02-25",
         "price": "$3.99",
-        "diamondSku": "DEC141239",
-        "userMetrics": {
-            "pulled": null,
-            "added": 44,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC141239"
     },
     {
         "id": "4821132",
@@ -1017,13 +681,7 @@
         "description": "It's the first Adventure Time starring its new creative team! With indie all-star Chris Hastings writing and the amazingly talented Zachary Sterling on art, these mathematical adventures are only going to get more algebraic!...",
         "releaseDate": "2015-01-28",
         "price": "$3.99",
-        "diamondSku": "NOV141132",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV141132"
     },
     {
         "id": "8276925",
@@ -1035,13 +693,7 @@
         "description": "It's the end of an era...the last ADVENTURE TIME issue featuring the Eisner Awardteam of Ryan North, Shelli Paroline, and Braden Lamb. It's your chance to say goodbye, and experience an adventure you'll never forget.",
         "releaseDate": "2014-12-24",
         "price": "$3.99",
-        "diamondSku": "OCT141197",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT141197"
     },
     {
         "id": "4348530",
@@ -1053,13 +705,7 @@
         "description": "Finn has made it to Magic Man at last! It's time for this adventure to end and for Finn to finally get his memory back. It might seem like an easy end, but it looks like there is still one more trick up Magic Man's sleeve.",
         "releaseDate": "2014-12-03",
         "price": "$3.99",
-        "diamondSku": "SEP141181",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP141181"
     },
     {
         "id": "2543079",
@@ -1071,13 +717,7 @@
         "description": "Magic Man's hold on Finn is proving to be stronger than anyone had thought and it's taking the whole crew to band together to help their friend, only this time, there really might be nothing they can do. It's...",
         "releaseDate": "2014-10-29",
         "price": "$3.99",
-        "diamondSku": "AUG141192",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG141192"
     },
     {
         "id": "7201061",
@@ -1089,13 +729,7 @@
         "description": "Finn is on an impossible mission to break Mnemonoid’s curse so that he can finally live his life…and remember it! It’s going to take a lot of pal time and a lot of help from the best of friends but this...",
         "releaseDate": "2014-10-01",
         "price": "$3.99",
-        "diamondSku": "JUL141004",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL141004"
     },
     {
         "id": "4699308",
@@ -1107,13 +741,7 @@
         "description": "When Princess Bubblegum and Marceline get their driver’s licenses, they have the perfect plan—build a giant ramp and drive off of it! It’s gonna be so much fun…wait, who’s the Mnemonoid, and...",
         "releaseDate": "2014-08-20",
         "price": "$3.99",
-        "diamondSku": "JUN140983",
-        "userMetrics": {
-            "pulled": null,
-            "added": 62,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN140983"
     },
     {
         "id": "2730049",
@@ -1125,13 +753,7 @@
         "description": "It's a rad stand-alone ZINE Special! Enjoy this crazy special as the citizens of Ooo create their own zines to share. Marceline has a lot to say about her music, Peppermint Butler has a few life tips for anyone who will...",
         "releaseDate": "2014-07-16",
         "price": "$3.99",
-        "diamondSku": "MAY141187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY141187"
     },
     {
         "id": "3714650",
@@ -1143,13 +765,7 @@
         "description": "Algebraic! Don't miss Finn, Jake, and all of their friends on their biggest adventure yet! Trapped by the dreaded Lich, the guys gotta stop all of Ooo from being sucked away forever - and rescue a bunch of wayward Princesses....",
         "releaseDate": "2012-04-11",
         "price": "$3.99",
-        "diamondSku": "FEB120869",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB120869"
     },
     {
         "id": "5910531",
@@ -1161,13 +777,7 @@
         "description": "Finn and Jake are back in their bodies, but it looks like the damage is done. Will our heroes be able to right everything they've done or is Ooo finally lost? With the help of an unlikely source, this day might be saved....",
         "releaseDate": "2014-06-18",
         "price": "$3.99",
-        "diamondSku": "APR141004",
-        "userMetrics": {
-            "pulled": null,
-            "added": 46,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR141004"
     },
     {
         "id": "7033633",
@@ -1179,13 +789,7 @@
         "description": "With one answer, there is always a million questions. Finn and Jake find themselves out of one problem and into another. It looks like it's going to be a race to the finish as our heroes discover what it really means...",
         "releaseDate": "2014-05-21",
         "price": "$3.99",
-        "diamondSku": "MAR140988",
-        "userMetrics": {
-            "pulled": null,
-            "added": 52,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR140988"
     },
     {
         "id": "2895692",
@@ -1197,13 +801,7 @@
         "description": "This special arc with guest artist Jim Rugg continues!! Finn and Jake might have finally met their match. but what will happen with it turns out that the match isn't a match at all? Things are getting crazy in the land of...",
         "releaseDate": "2014-04-16",
         "price": "$3.99",
-        "diamondSku": "FEB141084",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB141084"
     },
     {
         "id": "8151285",
@@ -1215,13 +813,7 @@
         "description": "Cover A: Mike Holmes Cover B: Craig Arndt Finn and Jake have always been best buds; they are always together, it's just something best buds do. But what happens when these two friends get separated on a crazy adventure...",
         "releaseDate": "2014-03-19",
         "price": "$3.99",
-        "diamondSku": "JAN141015",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN141015"
     },
     {
         "id": "7210049",
@@ -1233,13 +825,7 @@
         "description": "Ever have a favorite item? Something that you plan to keep with you always? Something that has a history back further than you can remember? Something precious...cherished...that will continue on after you've left on your...",
         "releaseDate": "2014-02-19",
         "price": "$4.99",
-        "diamondSku": "DEC130999",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC130999"
     },
     {
         "id": "6924403",
@@ -1251,13 +837,7 @@
         "description": "Princess Bubblegum faces the consequences of her science experiment gone wrong as she finally finds a way to save the day! But is it too late? Find out if Princess Bubblegum is able to right all her wrongs or if her friends...",
         "releaseDate": "2014-01-15",
         "price": "$3.99",
-        "diamondSku": "NOV130913",
-        "userMetrics": {
-            "pulled": null,
-            "added": 53,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV130913"
     },
     {
         "id": "2129061",
@@ -1269,13 +849,7 @@
         "description": "Will Princess Bubblegum be able to stop her creation from spreading, or is already too late for the Kingdom of Ooo?! With the Kingdoms Heroes under it's influence it leaves Marceline and Princess Bubblegum in a race again...",
         "releaseDate": "2013-12-18",
         "price": "$3.99",
-        "diamondSku": "OCT130970",
-        "userMetrics": {
-            "pulled": null,
-            "added": 57,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT130970"
     },
     {
         "id": "8724783",
@@ -1287,13 +861,7 @@
         "description": "Finn and Jake find themselves in a sticky situation when Princess Bubblegum's experiments searching for the origin of life...specifically, her life...go horribly wrong, overcoming the Candy Kingdom! What sour weapon can...",
         "releaseDate": "2013-11-20",
         "price": "$3.99",
-        "diamondSku": "SEP131006",
-        "userMetrics": {
-            "pulled": null,
-            "added": 57,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP131006"
     },
     {
         "id": "2882322",
@@ -1305,13 +873,7 @@
         "description": "It doesn't matter how many episodes or issues you get your hands on for ADVENTURE TIME, there will always be something new and amazing waiting for you behind every corner. The comic is a great read for allages and it's...",
         "releaseDate": "2013-10-16",
         "price": "$3.99",
-        "diamondSku": "AUG131132",
-        "userMetrics": {
-            "pulled": null,
-            "added": 63,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG131132"
     },
     {
         "id": "3124065",
@@ -1323,13 +885,7 @@
         "description": "Finn and Jake have endured the Ice King's weird emotional dungeon adventure, and the fiery pits created by Marceline's dad...what will their final dungeon adventure bring? A great jumping-on point for dungeon masters...",
         "releaseDate": "2013-09-18",
         "price": "$3.99",
-        "diamondSku": "JUL130958",
-        "userMetrics": {
-            "pulled": null,
-            "added": 61,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL130958"
     },
     {
         "id": "5232458",
@@ -1341,13 +897,7 @@
         "description": "It's Totally Mathematical! Join Finn, Jake, and all of their friends in this second issue of the ongoing comic book series showcasing all-new adventures through the magical Land of Ooo. The boys have embarked on another...",
         "releaseDate": "2012-03-14",
         "price": "$3.99",
-        "diamondSku": "JAN120971",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN120971"
     },
     {
         "id": "8840442",
@@ -1359,13 +909,7 @@
         "description": "The TOTALLY MATH adventure continues with Finn and Jake, everyone's favorite human and his dog! And this arc, things are getting literally mathematical for our heroes... The newest issue of the hottest allages book on...",
         "releaseDate": "2013-08-21",
         "price": "$3.99",
-        "diamondSku": "JUN130920",
-        "userMetrics": {
-            "pulled": null,
-            "added": 58,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN130920"
     },
     {
         "id": "3518528",
@@ -1377,13 +921,7 @@
         "description": "The TOTALLY MATH adventure continues with Finn and Jake, everyone's favorite human and dog duo! Will the guys find a way out of their dungeon despair, or will they have to settle for hanging with some tops blooby skeleton...",
         "releaseDate": "2013-07-17",
         "price": "$3.99",
-        "diamondSku": "MAY130960",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY130960"
     },
     {
         "id": "8765342",
@@ -1395,13 +933,7 @@
         "description": "It's a new TOTALLY MATH adventure for Finn and Jake, everyone's favorite boy and his dog! And this time, we mean that",
         "releaseDate": "2013-06-26",
         "price": "$3.99",
-        "diamondSku": "APR130968",
-        "userMetrics": {
-            "pulled": null,
-            "added": 65,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR130968"
     },
     {
         "id": "6416927",
@@ -1413,13 +945,7 @@
         "description": "THE FIRST ISSUE OF A NEW ARC AND THE PERFECT JUMPING-ON POINT FOR NEW READERS! It's an all-new adventure for Finn, Jake and the gang from critically acclaimed writer Ryan North! The best all-ages series of 2012 continues!",
         "releaseDate": "2013-05-22",
         "price": "$3.99",
-        "diamondSku": "MAR130943",
-        "userMetrics": {
-            "pulled": null,
-            "added": 59,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR130943"
     },
     {
         "id": "4694804",
@@ -1431,13 +957,7 @@
         "description": "A STAND-ALONE ISSUE LEADING INTO THE NEW ARC! A PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human in this totally topsy-turvy take on the land of Ooo! The best all-ages series of 2012 continues!...",
         "releaseDate": "2013-04-17",
         "price": "$3.99",
-        "diamondSku": "FEB130836",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB130836"
     },
     {
         "id": "5112162",
@@ -1449,13 +969,7 @@
         "description": "FINAL ISSUE OF THE ARC! Finn and Jake are trapped inside a digital world...who can rescue the heroes? Find out in the latest installment of \"the best comic of 2012!\" An all-ages sensation!",
         "releaseDate": "2013-03-20",
         "price": "$3.99",
-        "diamondSku": "JAN130975",
-        "userMetrics": {
-            "pulled": null,
-            "added": 70,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN130975"
     },
     {
         "id": "5012608",
@@ -1467,13 +981,7 @@
         "description": "CRITICS ARE CALLING ADVENTURE TIME THE \"BEST SERIES OF 2012!\" The latest issue of the hottest all-ages comic on the stands now! Join Finn and Jake as they work to save BMO from a magical virus...by going INSIDE...",
         "releaseDate": "2013-02-20",
         "price": "$3.99",
-        "diamondSku": "DEC120942",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC120942"
     },
     {
         "id": "7883919",
@@ -1485,13 +993,7 @@
         "description": "THE HOTTEST ALL-AGES COMIC CELEBRATES ITS ONE YEAR ANNIVERSARY! BMO's sick, but it's not just any virus...it's a magical virus! And now, Finn and Jake have to seek out a sorta-no-good-very-bad wizard to set things right!...",
         "releaseDate": "2013-01-30",
         "price": "$3.99",
-        "diamondSku": "NOV120968",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV120968"
     },
     {
         "id": "6782447",
@@ -1503,13 +1005,7 @@
         "description": "THE FINAL TOTALLY AWESOME ISSUE OF THIS ADVENTURE TIME MINI-SERIES! Can the Scream Queens rock their crazy-huge biggest gig ever...and will Princess Bubblegum finally discover the true meaning of ROCK? Final issue of this...",
         "releaseDate": "2012-12-19",
         "price": "$3.99",
-        "diamondSku": "OCT120924",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT120924"
     },
     {
         "id": "9426413",
@@ -1521,13 +1017,7 @@
         "description": "THERE'S NO BETTER TIME TO JUMP INTO THE ALL-AGES SENSATION! Join Jake the Dog and Finn the Human as they have sensational adventures in the magical land of Ooo! If you haven't checked out the comic book adaptation...",
         "releaseDate": "2012-11-28",
         "price": "$3.99",
-        "diamondSku": "SEP120936",
-        "userMetrics": {
-            "pulled": null,
-            "added": 60,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP120936"
     },
     {
         "id": "4281652",
@@ -1539,12 +1029,6 @@
         "description": "It's Adventure Time! Join Finn the Human, Jake the Dog, and Princess Bubblegum for all-new adventures through The Land of Ooo. The top-rated Cartoon Network show now has its own comic book! With the show exploding in the...",
         "releaseDate": "2012-02-08",
         "price": "$3.99",
-        "diamondSku": "DEC110939",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC110939"
     }
 ]

--- a/test/shared/new-comics/test-data/all-issues-2016-01-04.json
+++ b/test/shared/new-comics/test-data/all-issues-2016-01-04.json
@@ -9,13 +9,7 @@
         "description": "In these stories from 100 BULLETS #59-80, the Houses of the Trust are looking for the right angle in their impending war, while the Minutemen choose sides and make their own battle plans. Then, following Lono's ascension...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "OCT150272",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150272"
     },
     {
         "id": "8951361",
@@ -27,13 +21,7 @@
         "description": "Judge Dredd: Street Cred\n\n\tKingdom: Beast of Eden (Pt2)\n\n\tThe ABC Warriors: Return to Ro-Busters (Pt2)\n\n\tThe Order: In the Court of the Wyrmqueen (pt2)\n\n\tStrontium Dog: Repo Men (Pt2)",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3099238",
@@ -45,13 +33,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150736",
-        "userMetrics": {
-            "pulled": null,
-            "added": 652,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "OCT150736"
     },
     {
         "id": "3099238",
@@ -63,13 +45,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150740",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150740"
     },
     {
         "id": "3099238",
@@ -81,13 +57,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150738",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150738"
     },
     {
         "id": "3099238",
@@ -99,13 +69,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150739",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150739"
     },
     {
         "id": "8938200",
@@ -117,13 +81,7 @@
         "description": "“The Savage Dawn” begins! Following recent events in the SUPERMAN ANNUAL, Superman is becoming increasingly desperate to regain his powers! The situation is dire, as he must rescue his fellow Justice Leaguers...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150209",
-        "userMetrics": {
-            "pulled": null,
-            "added": 267,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150209"
     },
     {
         "id": "8938200",
@@ -135,13 +93,7 @@
         "description": "“The Savage Dawn” begins! Following recent events in the SUPERMAN ANNUAL, Superman is becoming increasingly desperate to regain his powers! The situation is dire, as he must rescue his fellow Justice Leaguers...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150210",
-        "userMetrics": {
-            "pulled": null,
-            "added": 29,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150210"
     },
     {
         "id": "6714034",
@@ -153,13 +105,7 @@
         "description": "Ricardo Delgado's Age of Reptiles series returns and marks a bold, new direction in wordless storytelling! The steaming swamps of Cretaceous Africa teem with prehistoric life and primordial danger in a tale filled with...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "SEP150062",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150062"
     },
     {
         "id": "8123690",
@@ -171,13 +117,7 @@
         "description": "The death toll mounts, and the fate of the Xenomorph that hatched from within Vampirella stands revealed! Meanwhile, the Martian Base pays the price for its mistrust of Vampirella as she and Lars deal with a horrifying threat...",
         "releaseDate": "2016-01-06",
         "price": "$50.00",
-        "diamondSku": "NOV151310",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151310"
     },
     {
         "id": "3924296",
@@ -189,13 +129,7 @@
         "description": "The End of Everything Part 1. The fifth arc of AMELIA COLE starts here, and folks, we're not gonna lie: everything's coming to a head. This is it. The stakes have never been higher. It's AMELIA COLE VERSUS THE...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9162719",
@@ -207,13 +141,7 @@
         "description": "Faith faces off against Drusilla in a grudge match that could level Magic Town as Angel attempts to withstand Archaeus’s power over him. Meanwhile, a mysterious statue—a magical relic of great power—has...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150021",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150021"
     },
     {
         "id": "9162719",
@@ -225,13 +153,7 @@
         "description": "Faith faces off against Drusilla in a grudge match that could level Magic Town as Angel attempts to withstand Archaeus’s power over him. Meanwhile, a mysterious statue—a magical relic of great power—has...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150022",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150022"
     },
     {
         "id": "1494689",
@@ -243,13 +165,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150412",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150412"
     },
     {
         "id": "1494689",
@@ -261,13 +177,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": "NOV150414",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150414"
     },
     {
         "id": "1494689",
@@ -279,13 +189,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150413",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150413"
     },
     {
         "id": "5453965",
@@ -297,13 +201,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151097",
-        "userMetrics": {
-            "pulled": null,
-            "added": 301,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT151097"
     },
     {
         "id": "5453965",
@@ -315,13 +213,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151099",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151099"
     },
     {
         "id": "5453965",
@@ -333,13 +225,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151098",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151098"
     },
     {
         "id": "2548829",
@@ -351,13 +237,7 @@
         "description": "The first of its kind! A massive hardcover art book featuring the incredible images of Magic: The Gathering",
         "releaseDate": "2016-01-06",
         "price": "$39.99",
-        "diamondSku": "NOV151737",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151737"
     },
     {
         "id": "8833243",
@@ -369,13 +249,7 @@
         "description": "Continuing his quest to destroy the Red King, Lord Baltimore heads to the icy Baltic Sea and northern Russia, but he finds witchcraft in the streets of St. Petersburg and evil in its shadows. With new allies and fearsome...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "SEP150038",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150038"
     },
     {
         "id": "8687722",
@@ -387,13 +261,7 @@
         "description": "Shady federal agents have tasked bounty hunter Barb Wire with tracking down and delivering her former associate Avram Roman, or she’ll face dire consequences. With little choice but compliance, Barb learns that her...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150068",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150068"
     },
     {
         "id": "9635447",
@@ -405,13 +273,7 @@
         "description": "\"Scare Tactics\" Grayson, Red Hood, Red Robin and Harper Row have uncovered the full scope of Mother’s dangerous operation, and they’re ready to spring their trap! But there’s one problem: Cassandra...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150223",
-        "userMetrics": {
-            "pulled": null,
-            "added": 601,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150223"
     },
     {
         "id": "3939472",
@@ -423,13 +285,7 @@
         "description": "Collecting the first four issues of the new series! The Joker is dead. Arkham City is closed. As a new day begins, Bruce Wayne finds himself in devastating pain, recovering from his injuries and questioning whether his role...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150245",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150245"
     },
     {
         "id": "6402306",
@@ -441,13 +297,7 @@
         "description": "No good deed goes unpunished! Freeing the world from Brother Eye was only the beginning—with Neo-Gotham now standing as the only stable society in the known world, thousands of refugees have fled their war-torn cities...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150230",
-        "userMetrics": {
-            "pulled": null,
-            "added": 271,
-            "consensusVote": 80,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150230"
     },
     {
         "id": "6266131",
@@ -459,13 +309,7 @@
         "description": "Batman finds himself knee-deep in a new mystery involving a deadly new narcotic in Gotham City. Can the Dark Knight stop the threat before the entire town finds itself embroiled in a deadly gang war? Collects issues #30-34...",
         "releaseDate": "2016-01-06",
         "price": "$16.99",
-        "diamondSku": "OCT150247",
-        "userMetrics": {
-            "pulled": null,
-            "added": 37,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150247"
     },
     {
         "id": "5944369",
@@ -477,13 +321,7 @@
         "description": "Gotham City is decending into chaos at the hands of Anarky and his quest for revenge on both the villains and protectors of the city in these tales from DETECTIVE COMICS #35-40, DETECTIVE COMICS: ENDGAME #1 and DETECTIVE...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "SEP150289",
-        "userMetrics": {
-            "pulled": null,
-            "added": 26,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150289"
     },
     {
         "id": "4552215",
@@ -495,13 +333,7 @@
         "description": "NEW STORY ARC \"Extraordinary Machine\" uncovers the past of the Bitches' secret weapon Meiko Maki, how she went from promising engineer to killer—and the ace up her sleeve. From KELLY SUE DeCONNICK (PRETTY...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150504",
-        "userMetrics": {
-            "pulled": null,
-            "added": 387,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150504"
     },
     {
         "id": "6005852",
@@ -513,13 +345,7 @@
         "description": "“GODWORLD,” Part Three\n\n\tA meeting with the Godhead.",
         "releaseDate": "2016-01-06",
         "price": "$3.50",
-        "diamondSku": "NOV150594",
-        "userMetrics": {
-            "pulled": null,
-            "added": 314,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 9.3
-        }
+        "diamondSku": "NOV150594"
     },
     {
         "id": "1390873",
@@ -531,13 +357,7 @@
         "description": "While New Orleans' privileged prepare to party, the city's disenfranchised batten down for the storm of the century.  But with Rosa already on the horizon, can Virgil stop the horror headed for his town before she hits?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151644",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151644"
     },
     {
         "id": "1390873",
@@ -549,13 +369,7 @@
         "description": "While New Orleans' privileged prepare to party, the city's disenfranchised batten down for the storm of the century.  But with Rosa already on the horizon, can Virgil stop the horror headed for his town before she hits?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151645",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151645"
     },
     {
         "id": "9475174",
@@ -567,13 +381,7 @@
         "description": "What's black and white and red all over? The Deadpool Coloring Book when you've finished with it! Say goodbye to your scarlet pens and crimson pencils as you bring to life page after page of pinups featuring the claret-clad...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV150950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 32,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150950"
     },
     {
         "id": "4178256",
@@ -585,13 +393,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150878",
-        "userMetrics": {
-            "pulled": null,
-            "added": 220,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150878"
     },
     {
         "id": "4178256",
@@ -603,13 +405,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150880",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150880"
     },
     {
         "id": "4178256",
@@ -621,13 +417,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150881",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150881"
     },
     {
         "id": "4178256",
@@ -639,13 +429,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150882",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150882"
     },
     {
         "id": "4178256",
@@ -657,13 +441,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150879",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150879"
     },
     {
         "id": "4178256",
@@ -675,13 +453,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150883"
     },
     {
         "id": "6156318",
@@ -693,13 +465,7 @@
         "description": "Now serving on the side of the Allies as part of the Amanda Waller’s Bombshells program, Supergirl and Stargirl wonder if they still are being used as instruments of propaganda. Meanwhile, mythological creatures and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150253",
-        "userMetrics": {
-            "pulled": null,
-            "added": 410,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150253"
     },
     {
         "id": "7316310",
@@ -711,13 +477,7 @@
         "description": "World War II is over. The Cold War has begun. And the Age of the Super-hero is in decline. But where are the heroes of tomorrow? This is the opening chapter of DC: THE NEW FRONTIER, reprinted at just $1.00 with pages from...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 16,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150260"
     },
     {
         "id": "4870425",
@@ -729,13 +489,7 @@
         "description": "Overview:A very impressive new series by writer/artist Darwyn Cooke! Darwyn Cooke's generations-spanning miniseries chronicling the dawn of the DC Universe's Silver Age begins here! Told from the perspective of the...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150260"
     },
     {
         "id": "2118920",
@@ -747,13 +501,7 @@
         "description": "Darryl DMC McDaniels returns and fulfills on his promise to expand the Darryl Makes Comics universe! In our second graphic novel you'll meet more heroes like LAK6, Sifu Horus, and The Breaks! They are on the cusp of...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1653159",
@@ -765,13 +513,7 @@
         "description": "A delay in plans proves catastrophic for the Seven Deadly Daughters.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150601",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150601"
     },
     {
         "id": "3256027",
@@ -783,13 +525,7 @@
         "description": "When John Doe uncovers the conspiracy that led to his untimely demise, he comes face to face with his betrayers as he squares off against the villainous Purple Gang! The thrilling conclusion! A noir horror story by Bill...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150031",
-        "userMetrics": {
-            "pulled": null,
-            "added": 20,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150031"
     },
     {
         "id": "2624735",
@@ -801,13 +537,7 @@
         "description": "Deadpool knows who the imposter out to ruin him is!\n\t\n\t\tAnd he has the perfect bait to lure the baddie out...\n\t\n\t\t...his innocent daughter, Ellie!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150895",
-        "userMetrics": {
-            "pulled": null,
-            "added": 880,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150895"
     },
     {
         "id": "2624735",
@@ -819,13 +549,7 @@
         "description": "Deadpool knows who the imposter out to ruin him is!\n\t\n\t\tAnd he has the perfect bait to lure the baddie out...\n\t\n\t\t...his innocent daughter, Ellie!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150896",
-        "userMetrics": {
-            "pulled": null,
-            "added": 174,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150896"
     },
     {
         "id": "3158425",
@@ -837,13 +561,7 @@
         "description": "The Merc with the Mouth & the Soldier with the Scowl continue their time-hopping adventure! What happens now that Split Second's identity is revealed?",
         "releaseDate": "2016-01-06",
         "price": "$1.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4255414",
@@ -855,13 +573,7 @@
         "description": "It’s a heaping helping of the Merc with a Mouth, chock-full of the craziness that helped form a cult following! Deadpool crosses Loki, joins the Frightful Four, rubs shoulders with Black Panther, and goes into space...",
         "releaseDate": "2016-01-06",
         "price": "$125",
-        "diamondSku": "SEP150859",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150859"
     },
     {
         "id": "1617902",
@@ -873,13 +585,7 @@
         "description": "Official SECRET WARS tie-in! Well, not that SECRET WARS - we're talking the original epic from 1984! But wait, Deadpool wasn't in that series, right? Wrong! Prepare to learn the terrifying truth as the team behind...",
         "releaseDate": "2016-01-06",
         "price": "$15.99",
-        "diamondSku": "OCT150977",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150977"
     },
     {
         "id": "1635277",
@@ -891,13 +597,7 @@
         "description": "\"The Bronze Age Blood of Heroes\" In the wake of the Robin War and globe-hopping with the Justice League, Jim Gordon is looking forward to getting back to what he, and Batman, do best: taking out crime in Gotham...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150231",
-        "userMetrics": {
-            "pulled": null,
-            "added": 353,
-            "consensusVote": 92,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150231"
     },
     {
         "id": "1635277",
@@ -909,13 +609,7 @@
         "description": "\"The Bronze Age Blood of Heroes\" In the wake of the Robin War and globe-hopping with the Justice League, Jim Gordon is looking forward to getting back to what he, and Batman, do best: taking out crime in Gotham...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150232",
-        "userMetrics": {
-            "pulled": null,
-            "added": 68,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150232"
     },
     {
         "id": "6133408",
@@ -927,13 +621,7 @@
         "description": "THE ART OF PUKING WITHOUT PUKING Doctor Strange has gathered a circle of magic-using friends to try and best monitor magic in the Marvel Universe. But this tactic is too late as forces are destroying all magical objects...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150871",
-        "userMetrics": {
-            "pulled": null,
-            "added": 985,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "NOV150871"
     },
     {
         "id": "6133408",
@@ -945,13 +633,7 @@
         "description": "THE ART OF PUKING WITHOUT PUKING Doctor Strange has gathered a circle of magic-using friends to try and best monitor magic in the Marvel Universe. But this tactic is too late as forces are destroying all magical objects...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150872",
-        "userMetrics": {
-            "pulled": null,
-            "added": 46,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150872"
     },
     {
         "id": "7780828",
@@ -963,13 +645,7 @@
         "description": "'MEDICINE MAN' PART 1 It's back to the deep, deep past and the dawn of humanity for the Doctor and Gabby, as their travels take them to the Pleistocene - and the epic struggle between Neanderthal and Cro-Magnon...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151594",
-        "userMetrics": {
-            "pulled": null,
-            "added": 61,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151594"
     },
     {
         "id": "7780828",
@@ -981,13 +657,7 @@
         "description": "'MEDICINE MAN' PART 1 It's back to the deep, deep past and the dawn of humanity for the Doctor and Gabby, as their travels take them to the Pleistocene - and the epic struggle between Neanderthal and Cro-Magnon...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151595",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151595"
     },
     {
         "id": "6891645",
@@ -999,13 +669,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151659",
-        "userMetrics": {
-            "pulled": null,
-            "added": 54,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151659"
     },
     {
         "id": "6891645",
@@ -1017,13 +681,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151660",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151660"
     },
     {
         "id": "6891645",
@@ -1035,13 +693,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151661",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151661"
     },
     {
         "id": "6891645",
@@ -1053,13 +705,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151662",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151662"
     },
     {
         "id": "6891645",
@@ -1071,13 +717,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151663",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151663"
     },
     {
         "id": "6581246",
@@ -1089,13 +729,7 @@
         "description": "Cry havoc and let slip the dogs of war!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "AUG150557",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150557"
     },
     {
         "id": "1921643",
@@ -1107,13 +741,7 @@
         "description": "...And the door will open, part 2 Lilia Romanova is the ordinary Moscow girl preparing for college. Well, the «ordinary» would not be the right word for it, because Lilia is a geek - a passionate books, comics,...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9002997",
@@ -1125,13 +753,7 @@
         "description": "The FBP is scrambling to work with counter-agent Blackwood to restore universal laws of order. Is Agent Adam Hardy dead? Is his long-lost father alive? Does Agent Rosa Reyes have the secret key to spanning universes and...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150273",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150273"
     },
     {
         "id": "9729365",
@@ -1143,13 +765,7 @@
         "description": "Launching the second arc in the critically-acclaimed story of a boy and his dragon on the hunt for revenge in Depression-era New York City. The training begins.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150484",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150484"
     },
     {
         "id": "8236968",
@@ -1161,13 +777,7 @@
         "description": "The one-way time-traveling adventure continues as everyone's favorite agents James and Simon visit a secret location to put the 'con' in the infamous moon landing conspiracy. Was the Apollo 11 moon landing real...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "2339022",
@@ -1179,13 +789,7 @@
         "description": "The Sleepers Awaken! COBRA's covert agents, situated all over the world, activate and prepare to bring about the Cobra World Order. G.I. JOE scrambles to take them down—but it may just be too late! •COBRA's...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150343",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150343"
     },
     {
         "id": "2339022",
@@ -1197,13 +801,7 @@
         "description": "The Sleepers Awaken! COBRA's covert agents, situated all over the world, activate and prepare to bring about the Cobra World Order. G.I. JOE scrambles to take them down—but it may just be too late! •COBRA's...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150344",
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150344"
     },
     {
         "id": "7041748",
@@ -1215,13 +813,7 @@
         "description": "Esther’s old school friend “Big Lindsay” comes to visit with her baby, but watching the kid and being nice to the insatiable party girl begins to wear on everyone.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 129,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151188"
     },
     {
         "id": "3160480",
@@ -1233,13 +825,7 @@
         "description": "Kitten, Maribel, and Gaby are childhood friends celebrating their sixteenth birthday. But someone's missing-their fourth friend, Una, is imprisoned in Tijuana. So the girls set out to give Una the ultimate birthday gift-freedom-even...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "SEP150086",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150086"
     },
     {
         "id": "6239355",
@@ -1251,13 +837,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV151433",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151433"
     },
     {
         "id": "6239355",
@@ -1269,13 +849,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151436",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151436"
     },
     {
         "id": "6239355",
@@ -1287,13 +861,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV151434",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151434"
     },
     {
         "id": "8933551",
@@ -1305,13 +873,7 @@
         "description": "As a result of the traumatic effects of the recent ANNUAL #1, Oliver Queen has contracted the Lukos virus! As he struggles to find a cure, he must stay far away from his friends and family—or else he’ll tear...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 197,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150187"
     },
     {
         "id": "8933551",
@@ -1323,13 +885,7 @@
         "description": "As a result of the traumatic effects of the recent ANNUAL #1, Oliver Queen has contracted the Lukos virus! As he struggles to find a cure, he must stay far away from his friends and family—or else he’ll tear...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150188"
     },
     {
         "id": "1417597",
@@ -1341,13 +897,7 @@
         "description": "Back on Earth once more, Hal Jordan must bring in help to handle a terrorist attack on Coast City. But when Batman arrives on the scene, Green Lantern learns that much has changed while he was off-planet…",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150244",
-        "userMetrics": {
-            "pulled": null,
-            "added": 269,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150244"
     },
     {
         "id": "1417597",
@@ -1359,13 +909,7 @@
         "description": "Back on Earth once more, Hal Jordan must bring in help to handle a terrorist attack on Coast City. But when Batman arrives on the scene, Green Lantern learns that much has changed while he was off-planet…",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150245",
-        "userMetrics": {
-            "pulled": null,
-            "added": 36,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150245"
     },
     {
         "id": "4046124",
@@ -1377,13 +921,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151824",
-        "userMetrics": {
-            "pulled": null,
-            "added": 22,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151824"
     },
     {
         "id": "4046124",
@@ -1395,13 +933,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151825",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151825"
     },
     {
         "id": "4046124",
@@ -1413,13 +945,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151826",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151826"
     },
     {
         "id": "4431462",
@@ -1431,13 +957,7 @@
         "description": "The GUARDIANS 1000 have arrived! But they aren’t the only NEWCOMERS on the scene… The past is under attack, but is ANY time safe? Plus, DRAX GOES MISSING in a story by ROBBIE THOMPSON and MARCO CHECCHETTO!",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150805",
-        "userMetrics": {
-            "pulled": null,
-            "added": 272,
-            "consensusVote": 72,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150805"
     },
     {
         "id": "4431462",
@@ -1449,13 +969,7 @@
         "description": "The GUARDIANS 1000 have arrived! But they aren’t the only NEWCOMERS on the scene… The past is under attack, but is ANY time safe? Plus, DRAX GOES MISSING in a story by ROBBIE THOMPSON and MARCO CHECCHETTO!",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150806",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150806"
     },
     {
         "id": "7673190",
@@ -1467,13 +981,7 @@
         "description": "When an alien race discovers that Jean Grey is back on Earth, they decide to punish her for the genocidal crimes of Dark Phoenix! Now, the Guardians of the Galaxy must help the All-New X-Men save Jean from twisted intergalactic...",
         "releaseDate": "2016-01-06",
         "price": "$34.99",
-        "diamondSku": "JUL150826",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "JUL150826"
     },
     {
         "id": "5995172",
@@ -1485,13 +993,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5435134",
@@ -1503,13 +1005,7 @@
         "description": "Heavy Metal rings in the holidays with a bevy of rich content that would make even Scrooge blush! Erika Lewis' & Salvatore's cover feature 'The Little Mermaid' packs a potent holiday punch, Bilal's...",
         "releaseDate": "2016-01-06",
         "price": "$7.95",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5435134",
@@ -1521,13 +1017,7 @@
         "description": "Heavy Metal rings in the holidays with a bevy of rich content that would make even Scrooge blush! Erika Lewis' & Salvatore's cover feature 'The Little Mermaid' packs a potent holiday punch, Bilal's...",
         "releaseDate": "2016-01-06",
         "price": "$7.95",
-        "diamondSku": "OCT151494",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151494"
     },
     {
         "id": "5711938",
@@ -1539,13 +1029,7 @@
         "description": "The Crow King Saga: part 3 of 3--'Crow Confrontation'.  Cassiopeia has successfully reunited the Hero Cats, but now they must face their biggest challenge yet.  Don't miss the climatic conclusion of the Crow King Saga!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150972",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150972"
     },
     {
         "id": "1301606",
@@ -1557,13 +1041,7 @@
         "description": "In the past, the original El Vengador is forced to fight for his honor, while in the present, Carlos faces a military tribunal. As if that's not enough, Pelon threatens Oscar and his family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151649"
     },
     {
         "id": "1301606",
@@ -1575,13 +1053,7 @@
         "description": "In the past, the original El Vengador is forced to fight for his honor, while in the present, Carlos faces a military tribunal. As if that's not enough, Pelon threatens Oscar and his family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151650",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151650"
     },
     {
         "id": "4451772",
@@ -1593,13 +1065,7 @@
         "description": "Get 14 of the most popular hip-hop variants with this free sampler!",
         "releaseDate": "2016-01-06",
         "price": "$0.00",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 110,
-            "consensusVote": 88,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9637753",
@@ -1611,13 +1077,7 @@
         "description": "Twas the Night Before Christmas. This first issue features not one, but two Santa-centric tales of mayhem! First, Santa passes out drunk on Christmas Eve, and it's up to the other holiday icons to make sure the night...",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6549279",
@@ -1629,13 +1089,7 @@
         "description": "Little did Nao Kogure realize back in middle school that when she left an umbrella and a box of bandages in the rain for injured delinquent Taiga Onise she would meet him again in high school. Nao wants nothing to do with...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151746",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151746"
     },
     {
         "id": "1455329",
@@ -1647,13 +1101,7 @@
         "description": "This is it: the final year of INJUSTICE: GODS AMONG US, leading into the storyline of the hit videogame! Having defeated the Green Lantern Corps, the forces of magic, and now the gods themselves, the Regime seems to have...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 183,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150254"
     },
     {
         "id": "4720066",
@@ -1665,13 +1113,7 @@
         "description": "Interceptor tells the tale of Poli and Weep, two freedom fighters on a planet populated exclusively by blood-sucking vampires. A planet called Earth. From Donny Cates (Buzzkill, Ghost Fleet, and The Paybacks) and Dylan Burnett...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151495",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151495"
     },
     {
         "id": "4720066",
@@ -1683,13 +1125,7 @@
         "description": "Interceptor tells the tale of Poli and Weep, two freedom fighters on a planet populated exclusively by blood-sucking vampires. A planet called Earth. From Donny Cates (Buzzkill, Ghost Fleet, and The Paybacks) and Dylan Burnett...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4257000",
@@ -1701,13 +1137,7 @@
         "description": "Special one-shot issue written and drawn by KC Green (Gunshow, Graveyard Quest)! Three short tales answer the most-asked questions about everyone's favorite Irken Invader. Like, where can someone like ZIM get a bank...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151570",
-        "userMetrics": {
-            "pulled": null,
-            "added": 203,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151570"
     },
     {
         "id": "4257000",
@@ -1719,13 +1149,7 @@
         "description": "Special one-shot issue written and drawn by KC Green (Gunshow, Graveyard Quest)! Three short tales answer the most-asked questions about everyone's favorite Irken Invader. Like, where can someone like ZIM get a bank...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP158708",
-        "userMetrics": {
-            "pulled": null,
-            "added": 40,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP158708"
     },
     {
         "id": "7154190",
@@ -1737,13 +1161,7 @@
         "description": "The big finale to our big first storyline. Cards are turned over. Truths are revealed. Tony's life is turned upside down!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 846,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150732"
     },
     {
         "id": "1929908",
@@ -1755,13 +1173,7 @@
         "description": "Beneath the surface in the creature’s underwater lair, Joe Golem searches for the Drowning City’s missing children and finds more questions than answers. Tie-in to illustrated novel Joe Golem and the Drowning...",
         "releaseDate": "2016-01-06",
         "price": "$3.50",
-        "diamondSku": "NOV150019",
-        "userMetrics": {
-            "pulled": null,
-            "added": 59,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150019"
     },
     {
         "id": "9208763",
@@ -1773,13 +1185,7 @@
         "description": "Having been removed as leader of his beloved Russian fighter squadron, the Falcons, Johnny 'Red' Redburn is curious. What is this 'all-Russian' secret mission the Falcons are on and why has been forbidden to take part? However,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151651"
     },
     {
         "id": "9208763",
@@ -1791,13 +1197,7 @@
         "description": "Having been removed as leader of his beloved Russian fighter squadron, the Falcons, Johnny 'Red' Redburn is curious. What is this 'all-Russian' secret mission the Falcons are on and why has been forbidden to take part? However,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151652",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151652"
     },
     {
         "id": "3153779",
@@ -1809,13 +1209,7 @@
         "description": "Jughead has devised the perfect winter prank - and Archie can't wait to team up with him to get as many people as they can! But with Veronica as their first victim, will they successfully pull off their winter tricks, or...",
         "releaseDate": "2016-01-06",
         "price": "$5.99",
-        "diamondSku": "OCT151106",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151106"
     },
     {
         "id": "9773652",
@@ -1827,13 +1221,7 @@
         "description": "High school student Anise Yamamoto is the 'Rose Princess' of four handsome Rose Knights. Anise and her knights are fighting to defeat the Fake Rose Knights, but Kaede is losing to Shiden, the powerful Purple Rose, and faces...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151768",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151768"
     },
     {
         "id": "6275856",
@@ -1845,13 +1233,7 @@
         "description": "A daring robbery takes place and someone is trying to tear the Furious Five apart! The evidence points towards Tigress! Is she really a traitor? All will be revealed in 'Divide and Conquer'!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151665",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151665"
     },
     {
         "id": "6275856",
@@ -1863,13 +1245,7 @@
         "description": "A daring robbery takes place and someone is trying to tear the Furious Five apart! The evidence points towards Tigress! Is she really a traitor? All will be revealed in 'Divide and Conquer'!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151666",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151666"
     },
     {
         "id": "3652357",
@@ -1881,13 +1257,7 @@
         "description": "The Valley of Peace is rocked by a raging elemental storm that seems to have a life of its own. Po is just about capable of fighting anyone - but how can he battle the elements? And is a mystery villain behind the stormy...",
         "releaseDate": "2016-01-06",
         "price": "$6.99",
-        "diamondSku": "AUG151740",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG151740"
     },
     {
         "id": "4698089",
@@ -1899,13 +1269,7 @@
         "description": "The identity of Lara and Carter’s dangerous new enemy—Mr. Green—is revealed. The two adventurers use every weapon in their arsenal to stop a cult led by a madman who wants to remake the world . . . by destroying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150044",
-        "userMetrics": {
-            "pulled": null,
-            "added": 55,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150044"
     },
     {
         "id": "1246629",
@@ -1917,13 +1281,7 @@
         "description": "Major Gabriel Drum has arrived on Earth, emerging from the very asteroid he was left on over a year ago and looking noticably... different. Determined to speak with the President, he'll let nothing stand in his way,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151540",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151540"
     },
     {
         "id": "5348339",
@@ -1935,13 +1293,7 @@
         "description": "WORLD WAR THREE. The presence of alien life has been revealed to the people of Earth, and all hell has broken loose. A battle rages for control of the planet, between a US-led coalition of nations and a second group secretly...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "SEP151516",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151516"
     },
     {
         "id": "1525337",
@@ -1953,13 +1305,7 @@
         "description": "AD 2100: A devastating manmade plague is turning the human race into cannibalistic monsters known as the Thrall. But there is hope: young Daisy Ogami’s blood holds the secret to a cure—if Itto, her android protector,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150093",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150093"
     },
     {
         "id": "7310847",
@@ -1971,13 +1317,7 @@
         "description": "Free issue collecting 14 variant Hip-Hop covers.",
         "releaseDate": "2016-01-06",
         "price": "$0",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3647733",
@@ -1989,13 +1329,7 @@
         "description": "Featuring screen-capture images from MARVEL'S ULTIMATE SPIDER-MAN & MARVEL'S AVENGERS ASSEMBLE Web-slinging, avenging adventures based on the smash hit DISNEY XD animated series!",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "OCT150997",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150997"
     },
     {
         "id": "3287141",
@@ -2007,13 +1341,7 @@
         "description": "THE ROAD TO CAPTAIN AMERICA: CIVIL WAR BEGINS WITH THE OFFICIAL ADAPTATION OF THE SMASH HIT FILM CAPTAIN AMERICA: WINTER SOLDIER! When CAPTAIN AMERICA encounters an assassin named THE WINTER SOLDIER, he joins forces with...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150791",
-        "userMetrics": {
-            "pulled": null,
-            "added": 125,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150791"
     },
     {
         "id": "2902704",
@@ -2025,13 +1353,7 @@
         "description": "'Omigosh!' Mickey, Goofy, and Eurasia Toft jump from one epic quest to another-battling ghastly ghosts, putrid Pete, and an awesome planet-size parasite! Follow the thrills and laughs in 'Gift of the Sun Lord,'...",
         "releaseDate": "2016-01-06",
         "price": "$12.99",
-        "diamondSku": "NOV150436",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150436"
     },
     {
         "id": "5581086",
@@ -2043,13 +1365,7 @@
         "description": "As he recovers from an assault that hit him harder than he ever could have imagined, Midnighter finds himself back in the sights of Spyral…but this time, they want him on their side!",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150190",
-        "userMetrics": {
-            "pulled": null,
-            "added": 197,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150190"
     },
     {
         "id": "8240327",
@@ -2061,13 +1377,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150906",
-        "userMetrics": {
-            "pulled": null,
-            "added": 102,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150906"
     },
     {
         "id": "8240327",
@@ -2079,13 +1389,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150907",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150907"
     },
     {
         "id": "8240327",
@@ -2097,13 +1401,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150909",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150909"
     },
     {
         "id": "8240327",
@@ -2115,13 +1413,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150908"
     },
     {
         "id": "9285781",
@@ -2133,13 +1425,7 @@
         "description": "What's To Love: Created, written, and illustrated by incredible breakout talent and Russ Manning Promising Newcomer Award winner Jorge Corona (We Are...Robin, Teen Titans Go!), Feathers is a tale of danger, friendship, and...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT151228",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151228"
     },
     {
         "id": "9078196",
@@ -2151,13 +1437,7 @@
         "description": "Rarity has found a very difficult client in the form of Gilda the Griffon! Gilda demands the perfect uniform for a new sports team in Griffinstone. Rarity travels to the desolate kingdom and realizes there is more than fashion...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150424",
-        "userMetrics": {
-            "pulled": null,
-            "added": 26,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150424"
     },
     {
         "id": "9078196",
@@ -2169,13 +1449,7 @@
         "description": "Rarity has found a very difficult client in the form of Gilda the Griffon! Gilda demands the perfect uniform for a new sports team in Griffinstone. Rarity travels to the desolate kingdom and realizes there is more than fashion...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150425",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150425"
     },
     {
         "id": "9538949",
@@ -2187,13 +1461,7 @@
         "description": "Every year, Sunakawa receives chocolates from a mysterious 'Yukika Amami.' When the mystery girl shows up in person, she tells Takeo how she has loved Sunakawa for over ten years, and Takeo decides to give her his support!...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151748",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151748"
     },
     {
         "id": "3528060",
@@ -2205,13 +1473,7 @@
         "description": "Trine knows the answer to any question, except how she knows it. But that’s a mystery for later. The mystery for now concerns frozen mammoths in Siberia, and Trine, who never leaves London, wants to go see them herself....",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150063",
-        "userMetrics": {
-            "pulled": null,
-            "added": 39,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150063"
     },
     {
         "id": "6296245",
@@ -2223,13 +1485,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "SEP150592",
-        "userMetrics": {
-            "pulled": null,
-            "added": 98,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150592"
     },
     {
         "id": "6296245",
@@ -2241,13 +1497,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "8723904",
@@ -2259,13 +1509,7 @@
         "description": "Serial Killer Theater!",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150623",
-        "userMetrics": {
-            "pulled": null,
-            "added": 229,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150623"
     },
     {
         "id": "3653485",
@@ -2277,13 +1521,7 @@
         "description": "The members of Shikamaru’s team are out for revenge against their mentor’s murderers. Tsunade tries to stop them, but Kakashi wants to help! As the divide among the ninja grows, the mysterious Akatsuki organization...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "NOV151739",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151739"
     },
     {
         "id": "4240879",
@@ -2295,13 +1533,7 @@
         "description": "The third and final Naruto Box Set contains the thrilling conclusion to one of the most popular manga series of all time. This set features volumes 49-72 at a substantial savings over buying them individually, along with...",
         "releaseDate": "2016-01-06",
         "price": "$185.99",
-        "diamondSku": "NOV151738",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151738"
     },
     {
         "id": "8323817",
@@ -2313,13 +1545,7 @@
         "description": "With the world now safe and the ninja villages working together, Naruto's work as Hokage seems pretty mundane. Giving his son, Boruto, enough attention is the toughest task he has. But then Sasuke uncovers a conspiracy...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151741",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151741"
     },
     {
         "id": "3098003",
@@ -2331,13 +1557,7 @@
         "description": "Takashi Natsume can see the spirits and demons that hide from the rest of humanity. He has always been set apart from other people because of his gift, drifting from relative to relative, never fitting in. Now he's a troubled...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151770",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151770"
     },
     {
         "id": "4645284",
@@ -2349,13 +1569,7 @@
         "description": "For the first time, Ninjak's past and future collide in the pages of an all-new ongoing series from New York Times best-selling writer Matt Kindt (RAI, Mind MGMT) and superstar artists Clay Mann (X-Men: Legacy, Gambit)...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV151727",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151727"
     },
     {
         "id": "2790099",
@@ -2367,13 +1581,7 @@
         "description": "Haru learns that Raku and Chitoge's relationship isn't real! Haru didn't like Raku initially because she thought he was a playboy, but now that she's spent more time with him at the festival and knows about his false relationship......",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151745",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151745"
     },
     {
         "id": "6808616",
@@ -2385,13 +1593,7 @@
         "description": "Following the best-selling graphic novel Tales from Year Zero, Legendary takes you back to the front lines of a larger-than-life battleground with Pacific Rim: Tales From The Drift. The official new comic series presented...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 54,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151512"
     },
     {
         "id": "6808616",
@@ -2403,13 +1605,7 @@
         "description": "Following the best-selling graphic novel Tales from Year Zero, Legendary takes you back to the front lines of a larger-than-life battleground with Pacific Rim: Tales From The Drift. The official new comic series presented...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3173369",
@@ -2421,13 +1617,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 18.6
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "2247662",
@@ -2439,13 +1629,7 @@
         "description": "To prove themselves to the Pathfinder Society, Valeros the fighter and his companions must recount tales of their early exploits in a world beset by magic and evil. Thrill to the solo adventures of Valeros, holy warrior...",
         "releaseDate": "2016-01-06",
         "price": "$29.99",
-        "diamondSku": "SEP151254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151254"
     },
     {
         "id": "2897729",
@@ -2457,13 +1641,7 @@
         "description": "First, the terrible Sea Hag and Bluto train a giant ape to smash Popeye. The second story features Popeye with Swee’pea in an outlandish U.F.O. adventure, the third finds our two-eyed sailor with Olive Oyl. Plus an...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150478",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150478"
     },
     {
         "id": "2363308",
@@ -2475,13 +1653,7 @@
         "description": "Dr. Cruel is forcing Kenny to use his cube's near-limitless power in a bizarre plan for world domination and . . . love? But Kenny is through with letting other people run his life. With his robot friends at his side and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150047",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150047"
     },
     {
         "id": "5848401",
@@ -2493,13 +1665,7 @@
         "description": "Under the greatest secrecy, mysterious scientific experiments were conducted by the American Army; the consequences of which were as impressive as they were disturbing... Is there a link between them and the disasters which...",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1413218",
@@ -2511,13 +1677,7 @@
         "description": "In search of the Holy Grail, part 2 Nika Chaikina, the best thief in the world, is recruited by agent Delta from International Control Agency. \"ICA\" was created in the late 40's for one purpose - to prevent...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6856861",
@@ -2529,13 +1689,7 @@
         "description": "The concluding volume to New York Times best-selling author Scott Lobdell's run is here in RED HOOD AND THE OUTLAWS VOL. 7.  Batman's former sidekick Jason Todd, now known as the Red Hood, and his running mate...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150260"
     },
     {
         "id": "8738471",
@@ -2547,13 +1701,7 @@
         "description": "Red Sonja, now older and battle-scarred, has turned away from the warrior's lifestyle of bloodshed and vengeance. As the headmistress of an academy for sword maidens, she prepares a new generation of She-Devils to face...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "NOV151279",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151279"
     },
     {
         "id": "3818772",
@@ -2565,13 +1713,7 @@
         "description": "Rigby and Skips are forced to battle in the Crystal Coliseum while Benson and Mordecai struggle to find a way home from the Rainbow Palace in the clouds!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151193",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151193"
     },
     {
         "id": "3818772",
@@ -2583,13 +1725,7 @@
         "description": "Rigby and Skips are forced to battle in the Crystal Coliseum while Benson and Mordecai struggle to find a way home from the Rainbow Palace in the clouds!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151194",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151194"
     },
     {
         "id": "4434648",
@@ -2601,13 +1737,7 @@
         "description": "Number Two! In which Detective Trevor Churchill of the Terran Corporation discovers the only person more annoying than his alien partner is a clone of himself. In which we visit with Number Two, Trevor’s overworked...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151017",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV151017"
     },
     {
         "id": "9008844",
@@ -2619,13 +1749,7 @@
         "description": "\"That's what happens when you mess with the noblefolk!\" Bram and Weasel failed in rescuing the baby - as if you didn't see that coming. Now our couple of outlaws face an uncertain destiny. Well, not as...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP150945",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150945"
     },
     {
         "id": "5570666",
@@ -2637,13 +1761,7 @@
         "description": "The wild group of Saints exit to New Mexico after battling Michael's Southern Fried Henchmen. There an old friend of Blaise's plays some metal records backwards and accidentally conjures Baal, the prince of hell....",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150634",
-        "userMetrics": {
-            "pulled": null,
-            "added": 62,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150634"
     },
     {
         "id": "7806833",
@@ -2655,13 +1773,7 @@
         "description": "Beautiful. Intelligent. Deadly. Scarlett Couture is all of these things, and more. She's a spy. Using her cover as Head of Security for her mother's internationally renowned fashion house, she gathers intelligence...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "AUG151734",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG151734"
     },
     {
         "id": "4614283",
@@ -2673,13 +1785,7 @@
         "description": "Time ran out, and the Marvel Universe died. From the edge of Battleworld to the outskirts of infinity, every planet and star was expunged. Every life force extinguished. There are no survivors - except the Surfer, Dawn,...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "AUG150886",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150886"
     },
     {
         "id": "1802128",
@@ -2691,13 +1797,7 @@
         "description": "GWEN STACY: SPIDER-WOMAN! In one universe, it wasn’t Peter Parker bitten by the radioactive Spider, but Gwen Stacy! She’s smart, charming and can lift a car – Just don’t tell her Police Chief father!...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "OCT158414",
-        "userMetrics": {
-            "pulled": null,
-            "added": 13,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158414"
     },
     {
         "id": "5898719",
@@ -2709,13 +1809,7 @@
         "description": "GWEN TAKES ON THE GOBLINS!\n\t\n\t\t‘Nuff said.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150838",
-        "userMetrics": {
-            "pulled": null,
-            "added": 869,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150838"
     },
     {
         "id": "5898719",
@@ -2727,13 +1821,7 @@
         "description": "GWEN TAKES ON THE GOBLINS!\n\t\n\t\t‘Nuff said.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150839",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150839"
     },
     {
         "id": "3061927",
@@ -2745,13 +1833,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150751",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1205,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150751"
     },
     {
         "id": "3061927",
@@ -2763,13 +1845,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150756",
-        "userMetrics": {
-            "pulled": null,
-            "added": 91,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150756"
     },
     {
         "id": "3061927",
@@ -2781,13 +1857,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150753",
-        "userMetrics": {
-            "pulled": null,
-            "added": 98,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150753"
     },
     {
         "id": "3061927",
@@ -2799,13 +1869,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150754",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150754"
     },
     {
         "id": "3061927",
@@ -2817,13 +1881,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150755",
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150755"
     },
     {
         "id": "3061927",
@@ -2835,13 +1893,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -2853,13 +1905,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -2871,13 +1917,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -2889,13 +1929,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150752",
-        "userMetrics": {
-            "pulled": null,
-            "added": 175,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150752"
     },
     {
         "id": "3061927",
@@ -2907,13 +1941,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3173463",
@@ -2925,13 +1953,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9982295",
@@ -2943,13 +1965,7 @@
         "description": "Jessica Drew is a private investigator, a super hero and... a mom to be? Since we last saw her, Spider-Woman's got a whole NEW responsibility -- she's super heroing for two now, after all! Ben Urich and Porcupine are still...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158854",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158854"
     },
     {
         "id": "4073537",
@@ -2961,13 +1977,7 @@
         "description": "You met him as the navigator on the Bridge, but what roles did Pavel Chekov play aboard the ENTERPRISE before his promotion to the starboard seat? Find out as we go below decks for \"Ensign Chekov,\" heading your...",
         "releaseDate": "2016-01-06",
         "price": "$7.99",
-        "diamondSku": "NOV150365",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150365"
     },
     {
         "id": "5409995",
@@ -2979,13 +1989,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150366",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150366"
     },
     {
         "id": "5409995",
@@ -2997,13 +2001,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150367",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150367"
     },
     {
         "id": "5409995",
@@ -3015,13 +2013,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "7260681",
@@ -3033,13 +2025,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150945",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1167,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT150945"
     },
     {
         "id": "7260681",
@@ -3051,13 +2037,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150947",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150947"
     },
     {
         "id": "7260681",
@@ -3069,13 +2049,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150946",
-        "userMetrics": {
-            "pulled": null,
-            "added": 39,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150946"
     },
     {
         "id": "7260681",
@@ -3087,13 +2061,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6112591",
@@ -3105,13 +2073,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150917",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1052,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "NOV150917"
     },
     {
         "id": "6112591",
@@ -3123,13 +2085,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158450",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158450"
     },
     {
         "id": "6112591",
@@ -3141,13 +2097,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158874",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158874"
     },
     {
         "id": "6112591",
@@ -3159,13 +2109,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6112591",
@@ -3177,13 +2121,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150918",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150918"
     },
     {
         "id": "9170134",
@@ -3195,13 +2133,7 @@
         "description": "The tale of Darth Vader's transformation continues! Bounty Hunters are on the attack, and Vader has been given a new mission for the Empire. Unfortunately, it's completely at odds with his own personal mission. What's...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "OCT150987",
-        "userMetrics": {
-            "pulled": null,
-            "added": 184,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150987"
     },
     {
         "id": "7286756",
@@ -3213,13 +2145,7 @@
         "description": "'I can't speak to my brother. And don't tell me he's dead. I know he's been dead for years. But he has never been this silent.'",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP150946",
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150946"
     },
     {
         "id": "8617541",
@@ -3231,13 +2157,7 @@
         "description": "Three days from pulling off the crime of the century, Beth must confront the realization that she’s about to get everyone she’s ever loved killed...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150544",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150544"
     },
     {
         "id": "2064080",
@@ -3249,13 +2169,7 @@
         "description": "Six kids who lived through unbelievable horrors in 1987, now all grownup, are united in L.A. It’s monster versus monster (versus exorcists) in a torturous game between Mr. Empty and the Muskagee House. We discover...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150311",
-        "userMetrics": {
-            "pulled": null,
-            "added": 81,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150311"
     },
     {
         "id": "9416103",
@@ -3267,13 +2181,7 @@
         "description": "Swamp Thing returns in an all-new series written by his co-creator, legendary writer Len Wein! Swamp Thing has received an ominous warning, and now he finds himself under attack from the forces of dark magic. These are more...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150169",
-        "userMetrics": {
-            "pulled": null,
-            "added": 365,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 7
-        }
+        "diamondSku": "NOV150169"
     },
     {
         "id": "9416103",
@@ -3285,13 +2193,7 @@
         "description": "Swamp Thing returns in an all-new series written by his co-creator, legendary writer Len Wein! Swamp Thing has received an ominous warning, and now he finds himself under attack from the forces of dark magic. These are more...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150170",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150170"
     },
     {
         "id": "3261521",
@@ -3303,13 +2205,7 @@
         "description": "'City at War, Part 11!' The TMNT and Karai engage in a bloody battle against a dangerous group of Foot Elite Ninja, who are bent on avenging their dead Master Shredder!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150371",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150371"
     },
     {
         "id": "9415006",
@@ -3321,13 +2217,7 @@
         "description": "The Turtles take the fight to Baxter Stockman, while Karai decrees a 'Gauntlet' battle between ancient foes Splinter and Shredder all leading to a final showdown that will determine the fate of NYC, and the world,...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "NOV150369",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150369"
     },
     {
         "id": "2118857",
@@ -3339,13 +2229,7 @@
         "description": "Trapped deep underground on the planet Colu, Telos has the data he came for, and he’s ready to fight his way out. But his revolutionary teammates—Techne, K’Rot, Stealth, and Captain Comet—have other...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150204",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": 50,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150204"
     },
     {
         "id": "7792979",
@@ -3357,13 +2241,7 @@
         "description": "Peter Milligan, one of the comic industry's most groundbreaking writers (Shade: The Changing Man, X-Statix, Doop, Hellblazer), presents a tale of psychic powers gone awry, and one man's terrible battle with his own inner...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "OCT151357",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151357"
     },
     {
         "id": "8599700",
@@ -3375,13 +2253,7 @@
         "description": "The dead are rising in Harlem! Spider-Man relearns why graveyards are terrifying. But things aren't as simple as they seem (and they don't even seem all that simple). How do the Santerians fit into all of this?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150860",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 62,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150860"
     },
     {
         "id": "8599700",
@@ -3393,13 +2265,7 @@
         "description": "The dead are rising in Harlem! Spider-Man relearns why graveyards are terrifying. But things aren't as simple as they seem (and they don't even seem all that simple). How do the Santerians fit into all of this?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150861",
-        "userMetrics": {
-            "pulled": null,
-            "added": 86,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150861"
     },
     {
         "id": "2535230",
@@ -3411,13 +2277,7 @@
         "description": "Peter Parker is back! He's got a second chance at life, and he's not wasting a moment of it. But his old foes Electro and the Black Cat are back as well, re-energized and madder than ever! And a new revelation rocks...",
         "releaseDate": "2016-01-06",
         "price": "$34.99",
-        "diamondSku": "OCT150969",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150969"
     },
     {
         "id": "4442978",
@@ -3429,13 +2289,7 @@
         "description": "On her sixteenth birthday, orphan Himari Momochi inherits her ancestral estate that she's never seen. Momochi House exists on the barrier between the human and spiritual realms, and Himari is meant to act as guardian between...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151747",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151747"
     },
     {
         "id": "9543224",
@@ -3447,13 +2301,7 @@
         "description": "A horrific conspiracy has lurked at the back of American government for hundreds of years, and it seems First Lady Amelia Cole is caught in the conspirators' machinations. What do her visions have to do with the terrifying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150437",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150437"
     },
     {
         "id": "9543224",
@@ -3465,13 +2313,7 @@
         "description": "A horrific conspiracy has lurked at the back of American government for hundreds of years, and it seems First Lady Amelia Cole is caught in the conspirators' machinations. What do her visions have to do with the terrifying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150438",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150438"
     },
     {
         "id": "4361286",
@@ -3483,13 +2325,7 @@
         "description": "SERIES CONCLUSION\n\n\tIt all ends here! The dramatic wrap-up to the mystery and to Brubaker and Phillips' bestselling and most ambitious project yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150532",
-        "userMetrics": {
-            "pulled": null,
-            "added": 246,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 11.6
-        }
+        "diamondSku": "OCT150532"
     },
     {
         "id": "3881960",
@@ -3501,13 +2337,7 @@
         "description": "Last year, John Wick reminded everyone why hitmen make for awesome stories. Of course, we've known that for years as evidenced by The Killer and Hit. Ed Brisson's (Cluster, Sheltered) take on a retired hitman who...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151138",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151138"
     },
     {
         "id": "3881960",
@@ -3519,13 +2349,7 @@
         "description": "Last year, John Wick reminded everyone why hitmen make for awesome stories. Of course, we've known that for years as evidenced by The Killer and Hit. Ed Brisson's (Cluster, Sheltered) take on a retired hitman who...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151139",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151139"
     },
     {
         "id": "5559667",
@@ -3537,13 +2361,7 @@
         "description": "One brave Amazon stood against the rest, and won the right to escort the outsider beyond the boundaries of their world. Diana of Themyscira is about to face her biggest challenge yet!",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 15,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5551010",
@@ -3555,13 +2373,7 @@
         "description": "This is where all of Geoff and Vivian's training finally pays off as they battle the zombified hordes of Gristlewood in order to save their father and foil Merle Cope's plans to destroy the Allan family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150440",
-        "userMetrics": {
-            "pulled": null,
-            "added": 37,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150440"
     },
     {
         "id": "5551010",
@@ -3573,13 +2385,7 @@
         "description": "This is where all of Geoff and Vivian's training finally pays off as they battle the zombified hordes of Gristlewood in order to save their father and foil Merle Cope's plans to destroy the Allan family.",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": "NOV150441",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150441"
     },
     {
         "id": "8236974",
@@ -3591,13 +2397,7 @@
         "description": "Chris Henry is an American contractor in Iraq with a dead body on his hands and no idea what to do with it. That’s why he needs Nassir, one of the country’s last remaining old-school lawmen, to return the slain...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150309",
-        "userMetrics": {
-            "pulled": null,
-            "added": 175,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150309"
     },
     {
         "id": "3536399",
@@ -3609,13 +2409,7 @@
         "description": "THERE’S A BRAND NEW HULK IN TOWN, AND HIS NAME IS AMADEUS CHO! Get ready for the craziest Hulk story of the millennium as a kid genius decides he’s gonna be the best Hulk ever -- and just possibly brings the...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "OCT158855",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158855"
     },
     {
         "id": "2779253",
@@ -3627,13 +2421,7 @@
         "description": "CHO TIME CONTINUES AS THE HULK TAKES ON THE BIGGEST MONSTERS IN THE MARVEL UNIVERSE! But can Amadeus handle the brand-new danger of Lady Hellbender? Also: Trouble in the family! Snack time with Spidey! And more revelations...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150775",
-        "userMetrics": {
-            "pulled": null,
-            "added": 458,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150775"
     },
     {
         "id": "2779253",
@@ -3645,13 +2433,7 @@
         "description": "CHO TIME CONTINUES AS THE HULK TAKES ON THE BIGGEST MONSTERS IN THE MARVEL UNIVERSE! But can Amadeus handle the brand-new danger of Lady Hellbender? Also: Trouble in the family! Snack time with Spidey! And more revelations...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150776",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150776"
     },
     {
         "id": "5134003",
@@ -3663,13 +2445,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9331123",
@@ -3681,13 +2457,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150797",
-        "userMetrics": {
-            "pulled": null,
-            "added": 493,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150797"
     },
     {
         "id": "9331123",
@@ -3699,13 +2469,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150799",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150799"
     },
     {
         "id": "9331123",
@@ -3717,13 +2481,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150798",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150798"
     },
     {
         "id": "4553832",
@@ -3735,13 +2493,7 @@
         "description": "A house attacked. A daughter dying. An old, dead friend screaming out in pain. This wasn’t how it was supposed to go. The Vision created his family to be normal. This isn’t normal. This is terrifying. And it’s...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150795",
-        "userMetrics": {
-            "pulled": null,
-            "added": 763,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 14
-        }
+        "diamondSku": "NOV150795"
     },
     {
         "id": "4553832",
@@ -3753,13 +2505,7 @@
         "description": "A house attacked. A daughter dying. An old, dead friend screaming out in pain. This wasn’t how it was supposed to go. The Vision created his family to be normal. This isn’t normal. This is terrifying. And it’s...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150796",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150796"
     },
     {
         "id": "5339325",
@@ -3771,13 +2517,7 @@
         "description": "Calder isn’t strong enough, and Isaac gets caught messing with dangerous powers.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151180",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151180"
     },
     {
         "id": "2424300",
@@ -3789,13 +2529,7 @@
         "description": "Motherfather’s 1974 world tour has been one hell of a trip—and now, as the band’s traitor stands revealed, the devil himself has come to collect his due! Get your front-row tickets to the fiendish grand...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150020",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150020"
     },
     {
         "id": "4498595",
@@ -3807,13 +2541,7 @@
         "description": "Smertae and Riata battle with Macbeth’s fate hanging in the balance.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151185",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151185"
     },
     {
         "id": "3421032",
@@ -3825,13 +2553,7 @@
         "description": "Reprinting NEW MUTANTS #98.",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150859",
-        "userMetrics": {
-            "pulled": null,
-            "added": 287,
-            "consensusVote": 87,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150859"
     },
     {
         "id": "7748668",
@@ -3843,13 +2565,7 @@
         "description": "Reprinting WOLVERINE ORIGINS #25.",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150860",
-        "userMetrics": {
-            "pulled": null,
-            "added": 184,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150860"
     },
     {
         "id": "8773177",
@@ -3861,13 +2577,7 @@
         "description": "Benio learns both why Rokuro ran amok at Hinatsuki Dorm and a secret about her beloved brother. Then, when a friend is possessed by the curse of the Kegare, Rokuro is faced with a terrible decision",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151744",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151744"
     },
     {
         "id": "6152006",
@@ -3879,13 +2589,7 @@
         "description": "This is it - the swan song of the Ultimate Universe! As the Incursions destroy everything, and the Marvel and Ultimate Universes meet and collide, Miles Morales and the rest of the Ultimate heroes face final extinction!...",
         "releaseDate": "2016-01-06",
         "price": "$16.99",
-        "diamondSku": "SEP150866",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150866"
     },
     {
         "id": "9306813",
@@ -3897,13 +2601,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150769",
-        "userMetrics": {
-            "pulled": null,
-            "added": 753,
-            "consensusVote": 85,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT150769"
     },
     {
         "id": "9306813",
@@ -3915,13 +2613,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9306813",
@@ -3933,13 +2625,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150770",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150770"
     },
     {
         "id": "9306813",
@@ -3951,13 +2637,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9306813",
@@ -3969,13 +2649,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150771",
-        "userMetrics": {
-            "pulled": null,
-            "added": 17,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150771"
     },
     {
         "id": "7483434",
@@ -3987,13 +2661,7 @@
         "description": "With mutantkind in extinction’s crosshairs once more, Magneto leads a team of the deadliest X-Men to fight for the fate of their species! But can the Master of Magnetism curb his killer instincts long enough to find...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150890",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150890"
     },
     {
         "id": "7744104",
@@ -4005,13 +2673,7 @@
         "description": "Ever wonder why Scrooge stays a bachelor? In 'The Eternal Knot,' it's all about a decades-old gold miners' bet-until McDuck meets Gladys Dukehart, a mystery heiress whom it seems he can't refuse!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150432",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150432"
     },
     {
         "id": "7744104",
@@ -4023,13 +2685,7 @@
         "description": "Ever wonder why Scrooge stays a bachelor? In 'The Eternal Knot,' it's all about a decades-old gold miners' bet-until McDuck meets Gladys Dukehart, a mystery heiress whom it seems he can't refuse!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150433",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150433"
     },
     {
         "id": "5666561",
@@ -4041,13 +2697,7 @@
         "description": "The journey to the island doesn’t go quite as Dave expected when he meets hungover heiress Courtney, but you won’t hear him complaining. As each of the 140 arrives, social media mogul and Headspace mastermind...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150313",
-        "userMetrics": {
-            "pulled": null,
-            "added": 172,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150313"
     },
     {
         "id": "1037738",
@@ -4059,13 +2709,7 @@
         "description": "The Demon Dyspair has attacked the Earth. Six trapped souls, are given a second chance at life in order to fight this evil, however they are “resurrected” not so much as themselves, but on creatures that are...",
         "releaseDate": "2016-01-06",
         "price": "$10.00",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4008457",
@@ -4077,13 +2721,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4008457",
@@ -4095,13 +2733,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5111597",
@@ -4113,13 +2745,7 @@
         "description": "The war is tearing our world apart. Instead of big armies with tanks in the field, the Vampire War is fought in the streets, neighbor against neighbor, family against family. Night Terrors collects all-new prose stories...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "DEC140571",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "DEC140571"
     },
     {
         "id": "2341712",
@@ -4131,13 +2757,7 @@
         "description": "The war is tearing our world apart. Instead of big armies with tanks in the field, the Vampire War is fought in the streets, neighbor against neighbor, family against family. Night Terrors collects all-new prose stories...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "AUG150465",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150465"
     },
     {
         "id": "8652021",
@@ -4149,13 +2769,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151792",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151792"
     },
     {
         "id": "8652021",
@@ -4167,13 +2781,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151793",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151793"
     },
     {
         "id": "8652021",
@@ -4185,13 +2793,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151794",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151794"
     },
     {
         "id": "8652021",
@@ -4203,13 +2805,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151795",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151795"
     },
     {
         "id": "2089872",
@@ -4221,13 +2817,7 @@
         "description": "Lost! Defenseless! No way home! BECCA has no choice but to dive deeper into the chaos of WEIRDWORLD! GOLETA THE WIZARDSLAYER is becoming increasingly suspicious that Becca has overrepresented her experience in slaying wizards......",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150844",
-        "userMetrics": {
-            "pulled": null,
-            "added": 212,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150844"
     },
     {
         "id": "2089872",
@@ -4239,13 +2829,7 @@
         "description": "Lost! Defenseless! No way home! BECCA has no choice but to dive deeper into the chaos of WEIRDWORLD! GOLETA THE WIZARDSLAYER is becoming increasingly suspicious that Becca has overrepresented her experience in slaying wizards......",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150845",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150845"
     },
     {
         "id": "7324966",
@@ -4257,13 +2841,7 @@
         "description": "As the Neighbor invasion continues, Osamu's brave defense of Chika lands him in combat against the Neighbor commander! Border's weakest agent will have to do better than his best to win against a Trigger that seems to generate...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151763",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151763"
     },
     {
         "id": "8813065",
@@ -4275,13 +2853,7 @@
         "description": "Bailey Hoskins does not fit in. He never found just the right clique to hang out with, which makes high school difficult, but what happens when he sprouts mutant powers?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": 80,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1489106",
@@ -4293,13 +2865,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151708",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151708"
     },
     {
         "id": "1489106",
@@ -4311,13 +2877,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151709",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151709"
     },
     {
         "id": "1489106",
@@ -4329,13 +2889,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151710",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151710"
     },
     {
         "id": "1489106",
@@ -4347,13 +2901,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151711",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151711"
     },
     {
         "id": "6617764",
@@ -4365,12 +2913,6 @@
         "description": "Nate Adams was your regular, everyday kid, until he received the Yo-kai Watch, which allows him to see Yo-kai that are normally invisible to the naked eye!  For all ages.",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151762",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151762"
     }
 ]

--- a/test/shared/new-comics/test-data/filtered-issues-2016-01-04.json
+++ b/test/shared/new-comics/test-data/filtered-issues-2016-01-04.json
@@ -9,13 +9,7 @@
         "description": "NEW STORY ARC \"Extraordinary Machine\" uncovers the past of the Bitches' secret weapon Meiko Maki, how she went from promising engineer to killer—and the ace up her sleeve. From KELLY SUE DeCONNICK (PRETTY...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150504",
-        "userMetrics": {
-            "pulled": null,
-            "added": 387,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150504"
     },
     {
         "id": "6005852",
@@ -27,13 +21,7 @@
         "description": "“GODWORLD,” Part Three\n\n\tA meeting with the Godhead.",
         "releaseDate": "2016-01-06",
         "price": "$3.50",
-        "diamondSku": "NOV150594",
-        "userMetrics": {
-            "pulled": null,
-            "added": 314,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 9.3
-        }
+        "diamondSku": "NOV150594"
     },
     {
         "id": "1653159",
@@ -45,13 +33,7 @@
         "description": "A delay in plans proves catastrophic for the Seven Deadly Daughters.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150601",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150601"
     },
     {
         "id": "6581246",
@@ -63,13 +45,7 @@
         "description": "Cry havoc and let slip the dogs of war!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "AUG150557",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150557"
     },
     {
         "id": "9729365",
@@ -81,13 +57,7 @@
         "description": "Launching the second arc in the critically-acclaimed story of a boy and his dragon on the hunt for revenge in Depression-era New York City. The training begins.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150484",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150484"
     },
     {
         "id": "6296245",
@@ -99,13 +69,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "SEP150592",
-        "userMetrics": {
-            "pulled": null,
-            "added": 98,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150592"
     },
     {
         "id": "6296245",
@@ -117,13 +81,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "8723904",
@@ -135,13 +93,7 @@
         "description": "Serial Killer Theater!",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150623",
-        "userMetrics": {
-            "pulled": null,
-            "added": 229,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150623"
     },
     {
         "id": "3173369",
@@ -153,13 +105,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 18.6
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "5570666",
@@ -171,13 +117,7 @@
         "description": "The wild group of Saints exit to New Mexico after battling Michael's Southern Fried Henchmen. There an old friend of Blaise's plays some metal records backwards and accidentally conjures Baal, the prince of hell....",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150634",
-        "userMetrics": {
-            "pulled": null,
-            "added": 62,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150634"
     },
     {
         "id": "8617541",
@@ -189,13 +129,7 @@
         "description": "Three days from pulling off the crime of the century, Beth must confront the realization that she’s about to get everyone she’s ever loved killed...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150544",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150544"
     },
     {
         "id": "4361286",
@@ -207,12 +141,6 @@
         "description": "SERIES CONCLUSION\n\n\tIt all ends here! The dramatic wrap-up to the mystery and to Brubaker and Phillips' bestselling and most ambitious project yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150532",
-        "userMetrics": {
-            "pulled": null,
-            "added": 246,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 11.6
-        }
+        "diamondSku": "OCT150532"
     }
 ]

--- a/test/shared/new-comics/test-data/sorted-issues-2016-01-04.json
+++ b/test/shared/new-comics/test-data/sorted-issues-2016-01-04.json
@@ -9,13 +9,7 @@
         "description": "Nate Adams was your regular, everyday kid, until he received the Yo-kai Watch, which allows him to see Yo-kai that are normally invisible to the naked eye!  For all ages.",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151762",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151762"
     },
     {
         "id": "1489106",
@@ -27,13 +21,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151711",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151711"
     },
     {
         "id": "1489106",
@@ -45,13 +33,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151710",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151710"
     },
     {
         "id": "1489106",
@@ -63,13 +45,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151709",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151709"
     },
     {
         "id": "1489106",
@@ -81,13 +57,7 @@
         "description": "ALL-NEW ARC! ALL-NEW JUMPING-ON POINT! X-O MANOWAR AND NINJAK GO DEEP UNDERCOVER FOR…”THE KILL LIST”! With two kingdoms now under his command, Aric of Dacia has pledged loyalty to his adopted nation...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151708",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151708"
     },
     {
         "id": "8813065",
@@ -99,13 +69,7 @@
         "description": "Bailey Hoskins does not fit in. He never found just the right clique to hang out with, which makes high school difficult, but what happens when he sprouts mutant powers?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": 80,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "7324966",
@@ -117,13 +81,7 @@
         "description": "As the Neighbor invasion continues, Osamu's brave defense of Chika lands him in combat against the Neighbor commander! Border's weakest agent will have to do better than his best to win against a Trigger that seems to generate...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151763",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151763"
     },
     {
         "id": "2089872",
@@ -135,13 +93,7 @@
         "description": "Lost! Defenseless! No way home! BECCA has no choice but to dive deeper into the chaos of WEIRDWORLD! GOLETA THE WIZARDSLAYER is becoming increasingly suspicious that Becca has overrepresented her experience in slaying wizards......",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150845",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150845"
     },
     {
         "id": "2089872",
@@ -153,13 +105,7 @@
         "description": "Lost! Defenseless! No way home! BECCA has no choice but to dive deeper into the chaos of WEIRDWORLD! GOLETA THE WIZARDSLAYER is becoming increasingly suspicious that Becca has overrepresented her experience in slaying wizards......",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150844",
-        "userMetrics": {
-            "pulled": null,
-            "added": 212,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150844"
     },
     {
         "id": "8652021",
@@ -171,13 +117,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151795",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151795"
     },
     {
         "id": "8652021",
@@ -189,13 +129,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151794",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151794"
     },
     {
         "id": "8652021",
@@ -207,13 +141,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151793",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151793"
     },
     {
         "id": "8652021",
@@ -225,13 +153,7 @@
         "description": "GOD OF LIES Hades returns to Helsing, but his confession might tear them apart again. As the former god of hell delves into the truth about Dracula's origin, Dracula begins amassing a legion of his followers to paint...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151792",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151792"
     },
     {
         "id": "2341712",
@@ -243,13 +165,7 @@
         "description": "The war is tearing our world apart. Instead of big armies with tanks in the field, the Vampire War is fought in the streets, neighbor against neighbor, family against family. Night Terrors collects all-new prose stories...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "AUG150465",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150465"
     },
     {
         "id": "5111597",
@@ -261,13 +177,7 @@
         "description": "The war is tearing our world apart. Instead of big armies with tanks in the field, the Vampire War is fought in the streets, neighbor against neighbor, family against family. Night Terrors collects all-new prose stories...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "DEC140571",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "DEC140571"
     },
     {
         "id": "4008457",
@@ -279,13 +189,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4008457",
@@ -297,13 +201,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1037738",
@@ -315,13 +213,7 @@
         "description": "The Demon Dyspair has attacked the Earth. Six trapped souls, are given a second chance at life in order to fight this evil, however they are “resurrected” not so much as themselves, but on creatures that are...",
         "releaseDate": "2016-01-06",
         "price": "$10.00",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5666561",
@@ -333,13 +225,7 @@
         "description": "The journey to the island doesn’t go quite as Dave expected when he meets hungover heiress Courtney, but you won’t hear him complaining. As each of the 140 arrives, social media mogul and Headspace mastermind...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150313",
-        "userMetrics": {
-            "pulled": null,
-            "added": 172,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150313"
     },
     {
         "id": "7744104",
@@ -351,13 +237,7 @@
         "description": "Ever wonder why Scrooge stays a bachelor? In 'The Eternal Knot,' it's all about a decades-old gold miners' bet-until McDuck meets Gladys Dukehart, a mystery heiress whom it seems he can't refuse!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150433",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150433"
     },
     {
         "id": "7744104",
@@ -369,13 +249,7 @@
         "description": "Ever wonder why Scrooge stays a bachelor? In 'The Eternal Knot,' it's all about a decades-old gold miners' bet-until McDuck meets Gladys Dukehart, a mystery heiress whom it seems he can't refuse!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150432",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150432"
     },
     {
         "id": "7483434",
@@ -387,13 +261,7 @@
         "description": "With mutantkind in extinction’s crosshairs once more, Magneto leads a team of the deadliest X-Men to fight for the fate of their species! But can the Master of Magnetism curb his killer instincts long enough to find...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150890",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150890"
     },
     {
         "id": "9306813",
@@ -405,13 +273,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150771",
-        "userMetrics": {
-            "pulled": null,
-            "added": 17,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150771"
     },
     {
         "id": "9306813",
@@ -423,13 +285,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9306813",
@@ -441,13 +297,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150770",
-        "userMetrics": {
-            "pulled": null,
-            "added": 50,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150770"
     },
     {
         "id": "9306813",
@@ -459,13 +309,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9306813",
@@ -477,13 +321,7 @@
         "description": "In a world that's never hated or feared mutants more, there is only one constant: BIGGER THREATS REQUIRE MORE THREATENING X-MEN. Refusing to accept one more mutant death, the most ruthless mutants on Earth have banded...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150769",
-        "userMetrics": {
-            "pulled": null,
-            "added": 753,
-            "consensusVote": 85,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT150769"
     },
     {
         "id": "6152006",
@@ -495,13 +333,7 @@
         "description": "This is it - the swan song of the Ultimate Universe! As the Incursions destroy everything, and the Marvel and Ultimate Universes meet and collide, Miles Morales and the rest of the Ultimate heroes face final extinction!...",
         "releaseDate": "2016-01-06",
         "price": "$16.99",
-        "diamondSku": "SEP150866",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150866"
     },
     {
         "id": "8773177",
@@ -513,13 +345,7 @@
         "description": "Benio learns both why Rokuro ran amok at Hinatsuki Dorm and a secret about her beloved brother. Then, when a friend is possessed by the curse of the Kegare, Rokuro is faced with a terrible decision",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151744",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151744"
     },
     {
         "id": "7748668",
@@ -531,13 +357,7 @@
         "description": "Reprinting WOLVERINE ORIGINS #25.",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150860",
-        "userMetrics": {
-            "pulled": null,
-            "added": 184,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150860"
     },
     {
         "id": "3421032",
@@ -549,13 +369,7 @@
         "description": "Reprinting NEW MUTANTS #98.",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150859",
-        "userMetrics": {
-            "pulled": null,
-            "added": 287,
-            "consensusVote": 87,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150859"
     },
     {
         "id": "4498595",
@@ -567,13 +381,7 @@
         "description": "Smertae and Riata battle with Macbeth’s fate hanging in the balance.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151185",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151185"
     },
     {
         "id": "2424300",
@@ -585,13 +393,7 @@
         "description": "Motherfather’s 1974 world tour has been one hell of a trip—and now, as the band’s traitor stands revealed, the devil himself has come to collect his due! Get your front-row tickets to the fiendish grand...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150020",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150020"
     },
     {
         "id": "5339325",
@@ -603,13 +405,7 @@
         "description": "Calder isn’t strong enough, and Isaac gets caught messing with dangerous powers.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151180",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151180"
     },
     {
         "id": "4553832",
@@ -621,13 +417,7 @@
         "description": "A house attacked. A daughter dying. An old, dead friend screaming out in pain. This wasn’t how it was supposed to go. The Vision created his family to be normal. This isn’t normal. This is terrifying. And it’s...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150796",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150796"
     },
     {
         "id": "4553832",
@@ -639,13 +429,7 @@
         "description": "A house attacked. A daughter dying. An old, dead friend screaming out in pain. This wasn’t how it was supposed to go. The Vision created his family to be normal. This isn’t normal. This is terrifying. And it’s...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150795",
-        "userMetrics": {
-            "pulled": null,
-            "added": 763,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 14
-        }
+        "diamondSku": "NOV150795"
     },
     {
         "id": "9331123",
@@ -657,13 +441,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150798",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150798"
     },
     {
         "id": "9331123",
@@ -675,13 +453,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150799",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150799"
     },
     {
         "id": "9331123",
@@ -693,13 +465,7 @@
         "description": "Sometimes you can’t fix something without taking a look at the whole thing at once. Spacetime is broken. If The Ultimates want to fix it, they need to go... OUTSIDE. But who -- or WHAT -- is out there waiting for them?...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150797",
-        "userMetrics": {
-            "pulled": null,
-            "added": 493,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150797"
     },
     {
         "id": "5134003",
@@ -711,13 +477,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "2779253",
@@ -729,13 +489,7 @@
         "description": "CHO TIME CONTINUES AS THE HULK TAKES ON THE BIGGEST MONSTERS IN THE MARVEL UNIVERSE! But can Amadeus handle the brand-new danger of Lady Hellbender? Also: Trouble in the family! Snack time with Spidey! And more revelations...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150776",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150776"
     },
     {
         "id": "2779253",
@@ -747,13 +501,7 @@
         "description": "CHO TIME CONTINUES AS THE HULK TAKES ON THE BIGGEST MONSTERS IN THE MARVEL UNIVERSE! But can Amadeus handle the brand-new danger of Lady Hellbender? Also: Trouble in the family! Snack time with Spidey! And more revelations...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150775",
-        "userMetrics": {
-            "pulled": null,
-            "added": 458,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150775"
     },
     {
         "id": "3536399",
@@ -765,13 +513,7 @@
         "description": "THERE’S A BRAND NEW HULK IN TOWN, AND HIS NAME IS AMADEUS CHO! Get ready for the craziest Hulk story of the millennium as a kid genius decides he’s gonna be the best Hulk ever -- and just possibly brings the...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "OCT158855",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158855"
     },
     {
         "id": "8236974",
@@ -783,13 +525,7 @@
         "description": "Chris Henry is an American contractor in Iraq with a dead body on his hands and no idea what to do with it. That’s why he needs Nassir, one of the country’s last remaining old-school lawmen, to return the slain...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150309",
-        "userMetrics": {
-            "pulled": null,
-            "added": 175,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150309"
     },
     {
         "id": "5551010",
@@ -801,13 +537,7 @@
         "description": "This is where all of Geoff and Vivian's training finally pays off as they battle the zombified hordes of Gristlewood in order to save their father and foil Merle Cope's plans to destroy the Allan family.",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": "NOV150441",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150441"
     },
     {
         "id": "5551010",
@@ -819,13 +549,7 @@
         "description": "This is where all of Geoff and Vivian's training finally pays off as they battle the zombified hordes of Gristlewood in order to save their father and foil Merle Cope's plans to destroy the Allan family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150440",
-        "userMetrics": {
-            "pulled": null,
-            "added": 37,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150440"
     },
     {
         "id": "5559667",
@@ -837,13 +561,7 @@
         "description": "One brave Amazon stood against the rest, and won the right to escort the outsider beyond the boundaries of their world. Diana of Themyscira is about to face her biggest challenge yet!",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 15,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3881960",
@@ -855,13 +573,7 @@
         "description": "Last year, John Wick reminded everyone why hitmen make for awesome stories. Of course, we've known that for years as evidenced by The Killer and Hit. Ed Brisson's (Cluster, Sheltered) take on a retired hitman who...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151139",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151139"
     },
     {
         "id": "3881960",
@@ -873,13 +585,7 @@
         "description": "Last year, John Wick reminded everyone why hitmen make for awesome stories. Of course, we've known that for years as evidenced by The Killer and Hit. Ed Brisson's (Cluster, Sheltered) take on a retired hitman who...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151138",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151138"
     },
     {
         "id": "4361286",
@@ -891,13 +597,7 @@
         "description": "SERIES CONCLUSION\n\n\tIt all ends here! The dramatic wrap-up to the mystery and to Brubaker and Phillips' bestselling and most ambitious project yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150532",
-        "userMetrics": {
-            "pulled": null,
-            "added": 246,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 11.6
-        }
+        "diamondSku": "OCT150532"
     },
     {
         "id": "9543224",
@@ -909,13 +609,7 @@
         "description": "A horrific conspiracy has lurked at the back of American government for hundreds of years, and it seems First Lady Amelia Cole is caught in the conspirators' machinations. What do her visions have to do with the terrifying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150438",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150438"
     },
     {
         "id": "9543224",
@@ -927,13 +621,7 @@
         "description": "A horrific conspiracy has lurked at the back of American government for hundreds of years, and it seems First Lady Amelia Cole is caught in the conspirators' machinations. What do her visions have to do with the terrifying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150437",
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150437"
     },
     {
         "id": "4442978",
@@ -945,13 +633,7 @@
         "description": "On her sixteenth birthday, orphan Himari Momochi inherits her ancestral estate that she's never seen. Momochi House exists on the barrier between the human and spiritual realms, and Himari is meant to act as guardian between...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151747",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151747"
     },
     {
         "id": "2535230",
@@ -963,13 +645,7 @@
         "description": "Peter Parker is back! He's got a second chance at life, and he's not wasting a moment of it. But his old foes Electro and the Black Cat are back as well, re-energized and madder than ever! And a new revelation rocks...",
         "releaseDate": "2016-01-06",
         "price": "$34.99",
-        "diamondSku": "OCT150969",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150969"
     },
     {
         "id": "8599700",
@@ -981,13 +657,7 @@
         "description": "The dead are rising in Harlem! Spider-Man relearns why graveyards are terrifying. But things aren't as simple as they seem (and they don't even seem all that simple). How do the Santerians fit into all of this?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150861",
-        "userMetrics": {
-            "pulled": null,
-            "added": 86,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150861"
     },
     {
         "id": "8599700",
@@ -999,13 +669,7 @@
         "description": "The dead are rising in Harlem! Spider-Man relearns why graveyards are terrifying. But things aren't as simple as they seem (and they don't even seem all that simple). How do the Santerians fit into all of this?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150860",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 62,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150860"
     },
     {
         "id": "7792979",
@@ -1017,13 +681,7 @@
         "description": "Peter Milligan, one of the comic industry's most groundbreaking writers (Shade: The Changing Man, X-Statix, Doop, Hellblazer), presents a tale of psychic powers gone awry, and one man's terrible battle with his own inner...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "OCT151357",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151357"
     },
     {
         "id": "2118857",
@@ -1035,13 +693,7 @@
         "description": "Trapped deep underground on the planet Colu, Telos has the data he came for, and he’s ready to fight his way out. But his revolutionary teammates—Techne, K’Rot, Stealth, and Captain Comet—have other...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150204",
-        "userMetrics": {
-            "pulled": null,
-            "added": 64,
-            "consensusVote": 50,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150204"
     },
     {
         "id": "9415006",
@@ -1053,13 +705,7 @@
         "description": "The Turtles take the fight to Baxter Stockman, while Karai decrees a 'Gauntlet' battle between ancient foes Splinter and Shredder all leading to a final showdown that will determine the fate of NYC, and the world,...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "NOV150369",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150369"
     },
     {
         "id": "3261521",
@@ -1071,13 +717,7 @@
         "description": "'City at War, Part 11!' The TMNT and Karai engage in a bloody battle against a dangerous group of Foot Elite Ninja, who are bent on avenging their dead Master Shredder!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150371",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150371"
     },
     {
         "id": "9416103",
@@ -1089,13 +729,7 @@
         "description": "Swamp Thing returns in an all-new series written by his co-creator, legendary writer Len Wein! Swamp Thing has received an ominous warning, and now he finds himself under attack from the forces of dark magic. These are more...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150170",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150170"
     },
     {
         "id": "9416103",
@@ -1107,13 +741,7 @@
         "description": "Swamp Thing returns in an all-new series written by his co-creator, legendary writer Len Wein! Swamp Thing has received an ominous warning, and now he finds himself under attack from the forces of dark magic. These are more...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150169",
-        "userMetrics": {
-            "pulled": null,
-            "added": 365,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 7
-        }
+        "diamondSku": "NOV150169"
     },
     {
         "id": "2064080",
@@ -1125,13 +753,7 @@
         "description": "Six kids who lived through unbelievable horrors in 1987, now all grownup, are united in L.A. It’s monster versus monster (versus exorcists) in a torturous game between Mr. Empty and the Muskagee House. We discover...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150311",
-        "userMetrics": {
-            "pulled": null,
-            "added": 81,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150311"
     },
     {
         "id": "8617541",
@@ -1143,13 +765,7 @@
         "description": "Three days from pulling off the crime of the century, Beth must confront the realization that she’s about to get everyone she’s ever loved killed...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150544",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150544"
     },
     {
         "id": "7286756",
@@ -1161,13 +777,7 @@
         "description": "'I can't speak to my brother. And don't tell me he's dead. I know he's been dead for years. But he has never been this silent.'",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP150946",
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150946"
     },
     {
         "id": "9170134",
@@ -1179,13 +789,7 @@
         "description": "The tale of Darth Vader's transformation continues! Bounty Hunters are on the attack, and Vader has been given a new mission for the Empire. Unfortunately, it's completely at odds with his own personal mission. What's...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "OCT150987",
-        "userMetrics": {
-            "pulled": null,
-            "added": 184,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150987"
     },
     {
         "id": "6112591",
@@ -1197,13 +801,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150918",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150918"
     },
     {
         "id": "6112591",
@@ -1215,13 +813,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6112591",
@@ -1233,13 +825,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158874",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158874"
     },
     {
         "id": "6112591",
@@ -1251,13 +837,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158450",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158450"
     },
     {
         "id": "6112591",
@@ -1269,13 +849,7 @@
         "description": "VADER DOWN: THE CONCLUSION!\n\n\t\n\t\tLuke Skywalker--captured by the Empire!\n\t\n\t\tDarth Vader--beset by enemies on all sides!\n\t\n\t\tThe finale of the biggest Marvel Star Wars story yet!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150917",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1052,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "NOV150917"
     },
     {
         "id": "7260681",
@@ -1287,13 +861,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "7260681",
@@ -1305,13 +873,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150946",
-        "userMetrics": {
-            "pulled": null,
-            "added": 39,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150946"
     },
     {
         "id": "7260681",
@@ -1323,13 +885,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150947",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150947"
     },
     {
         "id": "7260681",
@@ -1341,13 +897,7 @@
         "description": "VADER DOWN, PART FIVE\n\n\t\n\t\tCHEWBACCA VERSUS BLACK KRRSANTAN!\n\t\n\t\tWhat else do you need?\n\t\n\t\tMarvel's first Star Wars event continues!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150945",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1167,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT150945"
     },
     {
         "id": "5409995",
@@ -1359,13 +909,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5409995",
@@ -1377,13 +921,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150367",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150367"
     },
     {
         "id": "5409995",
@@ -1395,13 +933,7 @@
         "description": "Don't miss the latest chapter of the blockbuster mini-series that introduces a brave new cast of cadets to Star Trek lore! What is the mystery at the heart of Starfleet that connects this new crew to Kirk, Spock and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150366",
-        "userMetrics": {
-            "pulled": null,
-            "added": 43,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150366"
     },
     {
         "id": "4073537",
@@ -1413,13 +945,7 @@
         "description": "You met him as the navigator on the Bridge, but what roles did Pavel Chekov play aboard the ENTERPRISE before his promotion to the starboard seat? Find out as we go below decks for \"Ensign Chekov,\" heading your...",
         "releaseDate": "2016-01-06",
         "price": "$7.99",
-        "diamondSku": "NOV150365",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150365"
     },
     {
         "id": "9982295",
@@ -1431,13 +957,7 @@
         "description": "Jessica Drew is a private investigator, a super hero and... a mom to be? Since we last saw her, Spider-Woman's got a whole NEW responsibility -- she's super heroing for two now, after all! Ben Urich and Porcupine are still...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT158854",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158854"
     },
     {
         "id": "3173463",
@@ -1449,13 +969,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -1467,13 +981,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -1485,13 +993,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150752",
-        "userMetrics": {
-            "pulled": null,
-            "added": 175,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150752"
     },
     {
         "id": "3061927",
@@ -1503,13 +1005,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 21,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -1521,13 +1017,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -1539,13 +1029,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "3061927",
@@ -1557,13 +1041,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150755",
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150755"
     },
     {
         "id": "3061927",
@@ -1575,13 +1053,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150754",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150754"
     },
     {
         "id": "3061927",
@@ -1593,13 +1065,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150753",
-        "userMetrics": {
-            "pulled": null,
-            "added": 98,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150753"
     },
     {
         "id": "3061927",
@@ -1611,13 +1077,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150756",
-        "userMetrics": {
-            "pulled": null,
-            "added": 91,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150756"
     },
     {
         "id": "3061927",
@@ -1629,13 +1089,7 @@
         "description": "BECAUSE YOU DEMANDED IT! The Webbed Wonder and the Merc with a Mouth are teaming up for their first ongoing series EVER! It's action, adventure and just a smattering of (b) romance in this episodic epic featuring the...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150751",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1205,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150751"
     },
     {
         "id": "5898719",
@@ -1647,13 +1101,7 @@
         "description": "GWEN TAKES ON THE GOBLINS!\n\t\n\t\t‘Nuff said.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150839",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150839"
     },
     {
         "id": "5898719",
@@ -1665,13 +1113,7 @@
         "description": "GWEN TAKES ON THE GOBLINS!\n\t\n\t\t‘Nuff said.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150838",
-        "userMetrics": {
-            "pulled": null,
-            "added": 869,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150838"
     },
     {
         "id": "1802128",
@@ -1683,13 +1125,7 @@
         "description": "GWEN STACY: SPIDER-WOMAN! In one universe, it wasn’t Peter Parker bitten by the radioactive Spider, but Gwen Stacy! She’s smart, charming and can lift a car – Just don’t tell her Police Chief father!...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "OCT158414",
-        "userMetrics": {
-            "pulled": null,
-            "added": 13,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT158414"
     },
     {
         "id": "4614283",
@@ -1701,13 +1137,7 @@
         "description": "Time ran out, and the Marvel Universe died. From the edge of Battleworld to the outskirts of infinity, every planet and star was expunged. Every life force extinguished. There are no survivors - except the Surfer, Dawn,...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "AUG150886",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150886"
     },
     {
         "id": "7806833",
@@ -1719,13 +1149,7 @@
         "description": "Beautiful. Intelligent. Deadly. Scarlett Couture is all of these things, and more. She's a spy. Using her cover as Head of Security for her mother's internationally renowned fashion house, she gathers intelligence...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "AUG151734",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG151734"
     },
     {
         "id": "5570666",
@@ -1737,13 +1161,7 @@
         "description": "The wild group of Saints exit to New Mexico after battling Michael's Southern Fried Henchmen. There an old friend of Blaise's plays some metal records backwards and accidentally conjures Baal, the prince of hell....",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150634",
-        "userMetrics": {
-            "pulled": null,
-            "added": 62,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150634"
     },
     {
         "id": "9008844",
@@ -1755,13 +1173,7 @@
         "description": "\"That's what happens when you mess with the noblefolk!\" Bram and Weasel failed in rescuing the baby - as if you didn't see that coming. Now our couple of outlaws face an uncertain destiny. Well, not as...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP150945",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150945"
     },
     {
         "id": "4434648",
@@ -1773,13 +1185,7 @@
         "description": "Number Two! In which Detective Trevor Churchill of the Terran Corporation discovers the only person more annoying than his alien partner is a clone of himself. In which we visit with Number Two, Trevor’s overworked...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151017",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV151017"
     },
     {
         "id": "3818772",
@@ -1791,13 +1197,7 @@
         "description": "Rigby and Skips are forced to battle in the Crystal Coliseum while Benson and Mordecai struggle to find a way home from the Rainbow Palace in the clouds!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151194",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151194"
     },
     {
         "id": "3818772",
@@ -1809,13 +1209,7 @@
         "description": "Rigby and Skips are forced to battle in the Crystal Coliseum while Benson and Mordecai struggle to find a way home from the Rainbow Palace in the clouds!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151193",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151193"
     },
     {
         "id": "8738471",
@@ -1827,13 +1221,7 @@
         "description": "Red Sonja, now older and battle-scarred, has turned away from the warrior's lifestyle of bloodshed and vengeance. As the headmistress of an academy for sword maidens, she prepares a new generation of She-Devils to face...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "NOV151279",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151279"
     },
     {
         "id": "6856861",
@@ -1845,13 +1233,7 @@
         "description": "The concluding volume to New York Times best-selling author Scott Lobdell's run is here in RED HOOD AND THE OUTLAWS VOL. 7.  Batman's former sidekick Jason Todd, now known as the Red Hood, and his running mate...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150260"
     },
     {
         "id": "1413218",
@@ -1863,13 +1245,7 @@
         "description": "In search of the Holy Grail, part 2 Nika Chaikina, the best thief in the world, is recruited by agent Delta from International Control Agency. \"ICA\" was created in the late 40's for one purpose - to prevent...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5848401",
@@ -1881,13 +1257,7 @@
         "description": "Under the greatest secrecy, mysterious scientific experiments were conducted by the American Army; the consequences of which were as impressive as they were disturbing... Is there a link between them and the disasters which...",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "2363308",
@@ -1899,13 +1269,7 @@
         "description": "Dr. Cruel is forcing Kenny to use his cube's near-limitless power in a bizarre plan for world domination and . . . love? But Kenny is through with letting other people run his life. With his robot friends at his side and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150047",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150047"
     },
     {
         "id": "2897729",
@@ -1917,13 +1281,7 @@
         "description": "First, the terrible Sea Hag and Bluto train a giant ape to smash Popeye. The second story features Popeye with Swee’pea in an outlandish U.F.O. adventure, the third finds our two-eyed sailor with Olive Oyl. Plus an...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150478",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150478"
     },
     {
         "id": "2247662",
@@ -1935,13 +1293,7 @@
         "description": "To prove themselves to the Pathfinder Society, Valeros the fighter and his companions must recount tales of their early exploits in a world beset by magic and evil. Thrill to the solo adventures of Valeros, holy warrior...",
         "releaseDate": "2016-01-06",
         "price": "$29.99",
-        "diamondSku": "SEP151254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151254"
     },
     {
         "id": "3173369",
@@ -1953,13 +1305,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 18.6
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "6808616",
@@ -1971,13 +1317,7 @@
         "description": "Following the best-selling graphic novel Tales from Year Zero, Legendary takes you back to the front lines of a larger-than-life battleground with Pacific Rim: Tales From The Drift. The official new comic series presented...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6808616",
@@ -1989,13 +1329,7 @@
         "description": "Following the best-selling graphic novel Tales from Year Zero, Legendary takes you back to the front lines of a larger-than-life battleground with Pacific Rim: Tales From The Drift. The official new comic series presented...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 54,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151512"
     },
     {
         "id": "2790099",
@@ -2007,13 +1341,7 @@
         "description": "Haru learns that Raku and Chitoge's relationship isn't real! Haru didn't like Raku initially because she thought he was a playboy, but now that she's spent more time with him at the festival and knows about his false relationship......",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151745",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151745"
     },
     {
         "id": "4645284",
@@ -2025,13 +1353,7 @@
         "description": "For the first time, Ninjak's past and future collide in the pages of an all-new ongoing series from New York Times best-selling writer Matt Kindt (RAI, Mind MGMT) and superstar artists Clay Mann (X-Men: Legacy, Gambit)...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV151727",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151727"
     },
     {
         "id": "3098003",
@@ -2043,13 +1365,7 @@
         "description": "Takashi Natsume can see the spirits and demons that hide from the rest of humanity. He has always been set apart from other people because of his gift, drifting from relative to relative, never fitting in. Now he's a troubled...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151770",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151770"
     },
     {
         "id": "8323817",
@@ -2061,13 +1377,7 @@
         "description": "With the world now safe and the ninja villages working together, Naruto's work as Hokage seems pretty mundane. Giving his son, Boruto, enough attention is the toughest task he has. But then Sasuke uncovers a conspiracy...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151741",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151741"
     },
     {
         "id": "4240879",
@@ -2079,13 +1389,7 @@
         "description": "The third and final Naruto Box Set contains the thrilling conclusion to one of the most popular manga series of all time. This set features volumes 49-72 at a substantial savings over buying them individually, along with...",
         "releaseDate": "2016-01-06",
         "price": "$185.99",
-        "diamondSku": "NOV151738",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151738"
     },
     {
         "id": "3653485",
@@ -2097,13 +1401,7 @@
         "description": "The members of Shikamaru’s team are out for revenge against their mentor’s murderers. Tsunade tries to stop them, but Kakashi wants to help! As the divide among the ninja grows, the mysterious Akatsuki organization...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "NOV151739",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151739"
     },
     {
         "id": "8723904",
@@ -2115,13 +1413,7 @@
         "description": "Serial Killer Theater!",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150623",
-        "userMetrics": {
-            "pulled": null,
-            "added": 229,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150623"
     },
     {
         "id": "6296245",
@@ -2133,13 +1425,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6296245",
@@ -2151,13 +1437,7 @@
         "description": "Waterson makes a fateful decision that may earn him eternal damnation.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "SEP150592",
-        "userMetrics": {
-            "pulled": null,
-            "added": 98,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150592"
     },
     {
         "id": "3528060",
@@ -2169,13 +1449,7 @@
         "description": "Trine knows the answer to any question, except how she knows it. But that’s a mystery for later. The mystery for now concerns frozen mammoths in Siberia, and Trine, who never leaves London, wants to go see them herself....",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150063",
-        "userMetrics": {
-            "pulled": null,
-            "added": 39,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150063"
     },
     {
         "id": "9538949",
@@ -2187,13 +1461,7 @@
         "description": "Every year, Sunakawa receives chocolates from a mysterious 'Yukika Amami.' When the mystery girl shows up in person, she tells Takeo how she has loved Sunakawa for over ten years, and Takeo decides to give her his support!...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151748",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151748"
     },
     {
         "id": "9078196",
@@ -2205,13 +1473,7 @@
         "description": "Rarity has found a very difficult client in the form of Gilda the Griffon! Gilda demands the perfect uniform for a new sports team in Griffinstone. Rarity travels to the desolate kingdom and realizes there is more than fashion...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150425",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150425"
     },
     {
         "id": "9078196",
@@ -2223,13 +1485,7 @@
         "description": "Rarity has found a very difficult client in the form of Gilda the Griffon! Gilda demands the perfect uniform for a new sports team in Griffinstone. Rarity travels to the desolate kingdom and realizes there is more than fashion...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150424",
-        "userMetrics": {
-            "pulled": null,
-            "added": 26,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150424"
     },
     {
         "id": "9285781",
@@ -2241,13 +1497,7 @@
         "description": "What's To Love: Created, written, and illustrated by incredible breakout talent and Russ Manning Promising Newcomer Award winner Jorge Corona (We Are...Robin, Teen Titans Go!), Feathers is a tale of danger, friendship, and...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT151228",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151228"
     },
     {
         "id": "8240327",
@@ -2259,13 +1509,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150908"
     },
     {
         "id": "8240327",
@@ -2277,13 +1521,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150909",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150909"
     },
     {
         "id": "8240327",
@@ -2295,13 +1533,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150907",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150907"
     },
     {
         "id": "8240327",
@@ -2313,13 +1545,7 @@
         "description": "The cast of the Golden Age converges on London to remember, to renew and to rejoice. Miracleman walks amongst the London’s Day crowds searching for answers — before revealing a miraculous gift to humankind! Then,...",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150906",
-        "userMetrics": {
-            "pulled": null,
-            "added": 102,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150906"
     },
     {
         "id": "5581086",
@@ -2331,13 +1557,7 @@
         "description": "As he recovers from an assault that hit him harder than he ever could have imagined, Midnighter finds himself back in the sights of Spyral…but this time, they want him on their side!",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150190",
-        "userMetrics": {
-            "pulled": null,
-            "added": 197,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150190"
     },
     {
         "id": "2902704",
@@ -2349,13 +1569,7 @@
         "description": "'Omigosh!' Mickey, Goofy, and Eurasia Toft jump from one epic quest to another-battling ghastly ghosts, putrid Pete, and an awesome planet-size parasite! Follow the thrills and laughs in 'Gift of the Sun Lord,'...",
         "releaseDate": "2016-01-06",
         "price": "$12.99",
-        "diamondSku": "NOV150436",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150436"
     },
     {
         "id": "3287141",
@@ -2367,13 +1581,7 @@
         "description": "THE ROAD TO CAPTAIN AMERICA: CIVIL WAR BEGINS WITH THE OFFICIAL ADAPTATION OF THE SMASH HIT FILM CAPTAIN AMERICA: WINTER SOLDIER! When CAPTAIN AMERICA encounters an assassin named THE WINTER SOLDIER, he joins forces with...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150791",
-        "userMetrics": {
-            "pulled": null,
-            "added": 125,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150791"
     },
     {
         "id": "3647733",
@@ -2385,13 +1593,7 @@
         "description": "Featuring screen-capture images from MARVEL'S ULTIMATE SPIDER-MAN & MARVEL'S AVENGERS ASSEMBLE Web-slinging, avenging adventures based on the smash hit DISNEY XD animated series!",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "OCT150997",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150997"
     },
     {
         "id": "7310847",
@@ -2403,13 +1605,7 @@
         "description": "Free issue collecting 14 variant Hip-Hop covers.",
         "releaseDate": "2016-01-06",
         "price": "$0",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1525337",
@@ -2421,13 +1617,7 @@
         "description": "AD 2100: A devastating manmade plague is turning the human race into cannibalistic monsters known as the Thrall. But there is hope: young Daisy Ogami’s blood holds the secret to a cure—if Itto, her android protector,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150093",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150093"
     },
     {
         "id": "5348339",
@@ -2439,13 +1629,7 @@
         "description": "WORLD WAR THREE. The presence of alien life has been revealed to the people of Earth, and all hell has broken loose. A battle rages for control of the planet, between a US-led coalition of nations and a second group secretly...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": "SEP151516",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151516"
     },
     {
         "id": "1246629",
@@ -2457,13 +1641,7 @@
         "description": "Major Gabriel Drum has arrived on Earth, emerging from the very asteroid he was left on over a year ago and looking noticably... different. Determined to speak with the President, he'll let nothing stand in his way,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151540",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151540"
     },
     {
         "id": "4698089",
@@ -2475,13 +1653,7 @@
         "description": "The identity of Lara and Carter’s dangerous new enemy—Mr. Green—is revealed. The two adventurers use every weapon in their arsenal to stop a cult led by a madman who wants to remake the world . . . by destroying...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150044",
-        "userMetrics": {
-            "pulled": null,
-            "added": 55,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150044"
     },
     {
         "id": "3652357",
@@ -2493,13 +1665,7 @@
         "description": "The Valley of Peace is rocked by a raging elemental storm that seems to have a life of its own. Po is just about capable of fighting anyone - but how can he battle the elements? And is a mystery villain behind the stormy...",
         "releaseDate": "2016-01-06",
         "price": "$6.99",
-        "diamondSku": "AUG151740",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG151740"
     },
     {
         "id": "6275856",
@@ -2511,13 +1677,7 @@
         "description": "A daring robbery takes place and someone is trying to tear the Furious Five apart! The evidence points towards Tigress! Is she really a traitor? All will be revealed in 'Divide and Conquer'!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151666",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151666"
     },
     {
         "id": "6275856",
@@ -2529,13 +1689,7 @@
         "description": "A daring robbery takes place and someone is trying to tear the Furious Five apart! The evidence points towards Tigress! Is she really a traitor? All will be revealed in 'Divide and Conquer'!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151665",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151665"
     },
     {
         "id": "9773652",
@@ -2547,13 +1701,7 @@
         "description": "High school student Anise Yamamoto is the 'Rose Princess' of four handsome Rose Knights. Anise and her knights are fighting to defeat the Fake Rose Knights, but Kaede is losing to Shiden, the powerful Purple Rose, and faces...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151768",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151768"
     },
     {
         "id": "3153779",
@@ -2565,13 +1713,7 @@
         "description": "Jughead has devised the perfect winter prank - and Archie can't wait to team up with him to get as many people as they can! But with Veronica as their first victim, will they successfully pull off their winter tricks, or...",
         "releaseDate": "2016-01-06",
         "price": "$5.99",
-        "diamondSku": "OCT151106",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151106"
     },
     {
         "id": "9208763",
@@ -2583,13 +1725,7 @@
         "description": "Having been removed as leader of his beloved Russian fighter squadron, the Falcons, Johnny 'Red' Redburn is curious. What is this 'all-Russian' secret mission the Falcons are on and why has been forbidden to take part? However,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151652",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151652"
     },
     {
         "id": "9208763",
@@ -2601,13 +1737,7 @@
         "description": "Having been removed as leader of his beloved Russian fighter squadron, the Falcons, Johnny 'Red' Redburn is curious. What is this 'all-Russian' secret mission the Falcons are on and why has been forbidden to take part? However,...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151651"
     },
     {
         "id": "1929908",
@@ -2619,13 +1749,7 @@
         "description": "Beneath the surface in the creature’s underwater lair, Joe Golem searches for the Drowning City’s missing children and finds more questions than answers. Tie-in to illustrated novel Joe Golem and the Drowning...",
         "releaseDate": "2016-01-06",
         "price": "$3.50",
-        "diamondSku": "NOV150019",
-        "userMetrics": {
-            "pulled": null,
-            "added": 59,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150019"
     },
     {
         "id": "7154190",
@@ -2637,13 +1761,7 @@
         "description": "The big finale to our big first storyline. Cards are turned over. Truths are revealed. Tony's life is turned upside down!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 846,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150732"
     },
     {
         "id": "4257000",
@@ -2655,13 +1773,7 @@
         "description": "Special one-shot issue written and drawn by KC Green (Gunshow, Graveyard Quest)! Three short tales answer the most-asked questions about everyone's favorite Irken Invader. Like, where can someone like ZIM get a bank...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP158708",
-        "userMetrics": {
-            "pulled": null,
-            "added": 40,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP158708"
     },
     {
         "id": "4257000",
@@ -2673,13 +1785,7 @@
         "description": "Special one-shot issue written and drawn by KC Green (Gunshow, Graveyard Quest)! Three short tales answer the most-asked questions about everyone's favorite Irken Invader. Like, where can someone like ZIM get a bank...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151570",
-        "userMetrics": {
-            "pulled": null,
-            "added": 203,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151570"
     },
     {
         "id": "4720066",
@@ -2691,13 +1797,7 @@
         "description": "Interceptor tells the tale of Poli and Weep, two freedom fighters on a planet populated exclusively by blood-sucking vampires. A planet called Earth. From Donny Cates (Buzzkill, Ghost Fleet, and The Paybacks) and Dylan Burnett...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4720066",
@@ -2709,13 +1809,7 @@
         "description": "Interceptor tells the tale of Poli and Weep, two freedom fighters on a planet populated exclusively by blood-sucking vampires. A planet called Earth. From Donny Cates (Buzzkill, Ghost Fleet, and The Paybacks) and Dylan Burnett...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151495",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151495"
     },
     {
         "id": "1455329",
@@ -2727,13 +1821,7 @@
         "description": "This is it: the final year of INJUSTICE: GODS AMONG US, leading into the storyline of the hit videogame! Having defeated the Green Lantern Corps, the forces of magic, and now the gods themselves, the Regime seems to have...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150254",
-        "userMetrics": {
-            "pulled": null,
-            "added": 183,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150254"
     },
     {
         "id": "6549279",
@@ -2745,13 +1833,7 @@
         "description": "Little did Nao Kogure realize back in middle school that when she left an umbrella and a box of bandages in the rain for injured delinquent Taiga Onise she would meet him again in high school. Nao wants nothing to do with...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151746",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151746"
     },
     {
         "id": "9637753",
@@ -2763,13 +1845,7 @@
         "description": "Twas the Night Before Christmas. This first issue features not one, but two Santa-centric tales of mayhem! First, Santa passes out drunk on Christmas Eve, and it's up to the other holiday icons to make sure the night...",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4451772",
@@ -2781,13 +1857,7 @@
         "description": "Get 14 of the most popular hip-hop variants with this free sampler!",
         "releaseDate": "2016-01-06",
         "price": "$0.00",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 110,
-            "consensusVote": 88,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "1301606",
@@ -2799,13 +1869,7 @@
         "description": "In the past, the original El Vengador is forced to fight for his honor, while in the present, Carlos faces a military tribunal. As if that's not enough, Pelon threatens Oscar and his family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151650",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151650"
     },
     {
         "id": "1301606",
@@ -2817,13 +1881,7 @@
         "description": "In the past, the original El Vengador is forced to fight for his honor, while in the present, Carlos faces a military tribunal. As if that's not enough, Pelon threatens Oscar and his family.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 14,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151649"
     },
     {
         "id": "5711938",
@@ -2835,13 +1893,7 @@
         "description": "The Crow King Saga: part 3 of 3--'Crow Confrontation'.  Cassiopeia has successfully reunited the Hero Cats, but now they must face their biggest challenge yet.  Don't miss the climatic conclusion of the Crow King Saga!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150972",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150972"
     },
     {
         "id": "5435134",
@@ -2853,13 +1905,7 @@
         "description": "Heavy Metal rings in the holidays with a bevy of rich content that would make even Scrooge blush! Erika Lewis' & Salvatore's cover feature 'The Little Mermaid' packs a potent holiday punch, Bilal's...",
         "releaseDate": "2016-01-06",
         "price": "$7.95",
-        "diamondSku": "OCT151494",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151494"
     },
     {
         "id": "5435134",
@@ -2871,13 +1917,7 @@
         "description": "Heavy Metal rings in the holidays with a bevy of rich content that would make even Scrooge blush! Erika Lewis' & Salvatore's cover feature 'The Little Mermaid' packs a potent holiday punch, Bilal's...",
         "releaseDate": "2016-01-06",
         "price": "$7.95",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "5995172",
@@ -2889,13 +1929,7 @@
         "description": "",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "7673190",
@@ -2907,13 +1941,7 @@
         "description": "When an alien race discovers that Jean Grey is back on Earth, they decide to punish her for the genocidal crimes of Dark Phoenix! Now, the Guardians of the Galaxy must help the All-New X-Men save Jean from twisted intergalactic...",
         "releaseDate": "2016-01-06",
         "price": "$34.99",
-        "diamondSku": "JUL150826",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "JUL150826"
     },
     {
         "id": "4431462",
@@ -2925,13 +1953,7 @@
         "description": "The GUARDIANS 1000 have arrived! But they aren’t the only NEWCOMERS on the scene… The past is under attack, but is ANY time safe? Plus, DRAX GOES MISSING in a story by ROBBIE THOMPSON and MARCO CHECCHETTO!",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150806",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150806"
     },
     {
         "id": "4431462",
@@ -2943,13 +1965,7 @@
         "description": "The GUARDIANS 1000 have arrived! But they aren’t the only NEWCOMERS on the scene… The past is under attack, but is ANY time safe? Plus, DRAX GOES MISSING in a story by ROBBIE THOMPSON and MARCO CHECCHETTO!",
         "releaseDate": "2016-01-06",
         "price": "$4.99",
-        "diamondSku": "NOV150805",
-        "userMetrics": {
-            "pulled": null,
-            "added": 272,
-            "consensusVote": 72,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150805"
     },
     {
         "id": "4046124",
@@ -2961,13 +1977,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151826",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151826"
     },
     {
         "id": "4046124",
@@ -2979,13 +1989,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151825",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151825"
     },
     {
         "id": "4046124",
@@ -2997,13 +2001,7 @@
         "description": "The Child of Darkness You know things are bad when Robyn's fate is in the hands of Cindy",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151824",
-        "userMetrics": {
-            "pulled": null,
-            "added": 22,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151824"
     },
     {
         "id": "1417597",
@@ -3015,13 +2013,7 @@
         "description": "Back on Earth once more, Hal Jordan must bring in help to handle a terrorist attack on Coast City. But when Batman arrives on the scene, Green Lantern learns that much has changed while he was off-planet…",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150245",
-        "userMetrics": {
-            "pulled": null,
-            "added": 36,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150245"
     },
     {
         "id": "1417597",
@@ -3033,13 +2025,7 @@
         "description": "Back on Earth once more, Hal Jordan must bring in help to handle a terrorist attack on Coast City. But when Batman arrives on the scene, Green Lantern learns that much has changed while he was off-planet…",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150244",
-        "userMetrics": {
-            "pulled": null,
-            "added": 269,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150244"
     },
     {
         "id": "8933551",
@@ -3051,13 +2037,7 @@
         "description": "As a result of the traumatic effects of the recent ANNUAL #1, Oliver Queen has contracted the Lukos virus! As he struggles to find a cure, he must stay far away from his friends and family—or else he’ll tear...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150188"
     },
     {
         "id": "8933551",
@@ -3069,13 +2049,7 @@
         "description": "As a result of the traumatic effects of the recent ANNUAL #1, Oliver Queen has contracted the Lukos virus! As he struggles to find a cure, he must stay far away from his friends and family—or else he’ll tear...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150187",
-        "userMetrics": {
-            "pulled": null,
-            "added": 197,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150187"
     },
     {
         "id": "6239355",
@@ -3087,13 +2061,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV151434",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151434"
     },
     {
         "id": "6239355",
@@ -3105,13 +2073,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV151436",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151436"
     },
     {
         "id": "6239355",
@@ -3123,13 +2085,7 @@
         "description": "From the mind of legendary creator Grant Morrison! The Pandavas mourn their dead as the Kauravas celebrate their apocalyptic bombardment of the Pandava forces. With the first day of war ending in the slaughter of countless...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV151433",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151433"
     },
     {
         "id": "3160480",
@@ -3141,13 +2097,7 @@
         "description": "Kitten, Maribel, and Gaby are childhood friends celebrating their sixteenth birthday. But someone's missing-their fourth friend, Una, is imprisoned in Tijuana. So the girls set out to give Una the ultimate birthday gift-freedom-even...",
         "releaseDate": "2016-01-06",
         "price": "$17.99",
-        "diamondSku": "SEP150086",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150086"
     },
     {
         "id": "7041748",
@@ -3159,13 +2109,7 @@
         "description": "Esther’s old school friend “Big Lindsay” comes to visit with her baby, but watching the kid and being nice to the insatiable party girl begins to wear on everyone.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151188",
-        "userMetrics": {
-            "pulled": null,
-            "added": 129,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151188"
     },
     {
         "id": "2339022",
@@ -3177,13 +2121,7 @@
         "description": "The Sleepers Awaken! COBRA's covert agents, situated all over the world, activate and prepare to bring about the Cobra World Order. G.I. JOE scrambles to take them down—but it may just be too late! •COBRA's...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150344",
-        "userMetrics": {
-            "pulled": null,
-            "added": 7,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150344"
     },
     {
         "id": "2339022",
@@ -3195,13 +2133,7 @@
         "description": "The Sleepers Awaken! COBRA's covert agents, situated all over the world, activate and prepare to bring about the Cobra World Order. G.I. JOE scrambles to take them down—but it may just be too late! •COBRA's...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150343",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150343"
     },
     {
         "id": "8236968",
@@ -3213,13 +2145,7 @@
         "description": "The one-way time-traveling adventure continues as everyone's favorite agents James and Simon visit a secret location to put the 'con' in the infamous moon landing conspiracy. Was the Apollo 11 moon landing real...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "9729365",
@@ -3231,13 +2157,7 @@
         "description": "Launching the second arc in the critically-acclaimed story of a boy and his dragon on the hunt for revenge in Depression-era New York City. The training begins.",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150484",
-        "userMetrics": {
-            "pulled": null,
-            "added": 51,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150484"
     },
     {
         "id": "9002997",
@@ -3249,13 +2169,7 @@
         "description": "The FBP is scrambling to work with counter-agent Blackwood to restore universal laws of order. Is Agent Adam Hardy dead? Is his long-lost father alive? Does Agent Rosa Reyes have the secret key to spanning universes and...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150273",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150273"
     },
     {
         "id": "1921643",
@@ -3267,13 +2181,7 @@
         "description": "...And the door will open, part 2 Lilia Romanova is the ordinary Moscow girl preparing for college. Well, the «ordinary» would not be the right word for it, because Lilia is a geek - a passionate books, comics,...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6581246",
@@ -3285,13 +2193,7 @@
         "description": "Cry havoc and let slip the dogs of war!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "AUG150557",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "AUG150557"
     },
     {
         "id": "6891645",
@@ -3303,13 +2205,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151663",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151663"
     },
     {
         "id": "6891645",
@@ -3321,13 +2217,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151662",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151662"
     },
     {
         "id": "6891645",
@@ -3339,13 +2229,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151661",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151661"
     },
     {
         "id": "6891645",
@@ -3357,13 +2241,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151660",
-        "userMetrics": {
-            "pulled": null,
-            "added": 9,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151660"
     },
     {
         "id": "6891645",
@@ -3375,13 +2253,7 @@
         "description": "'CLARA OSWALD AND THE SCHOOL OF DEATH' PART 1 The Golden Years of the Doctor and Clara begin, as the twelfth Doctor comics leap into Series 9! Writer Robbie Morrison is back with a year-long extravaganza that kicks...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151659",
-        "userMetrics": {
-            "pulled": null,
-            "added": 54,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151659"
     },
     {
         "id": "7780828",
@@ -3393,13 +2265,7 @@
         "description": "'MEDICINE MAN' PART 1 It's back to the deep, deep past and the dawn of humanity for the Doctor and Gabby, as their travels take them to the Pleistocene - and the epic struggle between Neanderthal and Cro-Magnon...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151595",
-        "userMetrics": {
-            "pulled": null,
-            "added": 10,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151595"
     },
     {
         "id": "7780828",
@@ -3411,13 +2277,7 @@
         "description": "'MEDICINE MAN' PART 1 It's back to the deep, deep past and the dawn of humanity for the Doctor and Gabby, as their travels take them to the Pleistocene - and the epic struggle between Neanderthal and Cro-Magnon...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "SEP151594",
-        "userMetrics": {
-            "pulled": null,
-            "added": 61,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP151594"
     },
     {
         "id": "6133408",
@@ -3429,13 +2289,7 @@
         "description": "THE ART OF PUKING WITHOUT PUKING Doctor Strange has gathered a circle of magic-using friends to try and best monitor magic in the Marvel Universe. But this tactic is too late as forces are destroying all magical objects...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150872",
-        "userMetrics": {
-            "pulled": null,
-            "added": 46,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150872"
     },
     {
         "id": "6133408",
@@ -3447,13 +2301,7 @@
         "description": "THE ART OF PUKING WITHOUT PUKING Doctor Strange has gathered a circle of magic-using friends to try and best monitor magic in the Marvel Universe. But this tactic is too late as forces are destroying all magical objects...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150871",
-        "userMetrics": {
-            "pulled": null,
-            "added": 985,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "NOV150871"
     },
     {
         "id": "1635277",
@@ -3465,13 +2313,7 @@
         "description": "\"The Bronze Age Blood of Heroes\" In the wake of the Robin War and globe-hopping with the Justice League, Jim Gordon is looking forward to getting back to what he, and Batman, do best: taking out crime in Gotham...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150232",
-        "userMetrics": {
-            "pulled": null,
-            "added": 68,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150232"
     },
     {
         "id": "1635277",
@@ -3483,13 +2325,7 @@
         "description": "\"The Bronze Age Blood of Heroes\" In the wake of the Robin War and globe-hopping with the Justice League, Jim Gordon is looking forward to getting back to what he, and Batman, do best: taking out crime in Gotham...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150231",
-        "userMetrics": {
-            "pulled": null,
-            "added": 353,
-            "consensusVote": 92,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150231"
     },
     {
         "id": "1617902",
@@ -3501,13 +2337,7 @@
         "description": "Official SECRET WARS tie-in! Well, not that SECRET WARS - we're talking the original epic from 1984! But wait, Deadpool wasn't in that series, right? Wrong! Prepare to learn the terrifying truth as the team behind...",
         "releaseDate": "2016-01-06",
         "price": "$15.99",
-        "diamondSku": "OCT150977",
-        "userMetrics": {
-            "pulled": null,
-            "added": 47,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150977"
     },
     {
         "id": "4255414",
@@ -3519,13 +2349,7 @@
         "description": "It’s a heaping helping of the Merc with a Mouth, chock-full of the craziness that helped form a cult following! Deadpool crosses Loki, joins the Frightful Four, rubs shoulders with Black Panther, and goes into space...",
         "releaseDate": "2016-01-06",
         "price": "$125",
-        "diamondSku": "SEP150859",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150859"
     },
     {
         "id": "3158425",
@@ -3537,13 +2361,7 @@
         "description": "The Merc with the Mouth & the Soldier with the Scowl continue their time-hopping adventure! What happens now that Split Second's identity is revealed?",
         "releaseDate": "2016-01-06",
         "price": "$1.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 38,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "2624735",
@@ -3555,13 +2373,7 @@
         "description": "Deadpool knows who the imposter out to ruin him is!\n\t\n\t\tAnd he has the perfect bait to lure the baddie out...\n\t\n\t\t...his innocent daughter, Ellie!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150896",
-        "userMetrics": {
-            "pulled": null,
-            "added": 174,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150896"
     },
     {
         "id": "2624735",
@@ -3573,13 +2385,7 @@
         "description": "Deadpool knows who the imposter out to ruin him is!\n\t\n\t\tAnd he has the perfect bait to lure the baddie out...\n\t\n\t\t...his innocent daughter, Ellie!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150895",
-        "userMetrics": {
-            "pulled": null,
-            "added": 880,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150895"
     },
     {
         "id": "3256027",
@@ -3591,13 +2397,7 @@
         "description": "When John Doe uncovers the conspiracy that led to his untimely demise, he comes face to face with his betrayers as he squares off against the villainous Purple Gang! The thrilling conclusion! A noir horror story by Bill...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150031",
-        "userMetrics": {
-            "pulled": null,
-            "added": 20,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150031"
     },
     {
         "id": "1653159",
@@ -3609,13 +2409,7 @@
         "description": "A delay in plans proves catastrophic for the Seven Deadly Daughters.",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150601",
-        "userMetrics": {
-            "pulled": null,
-            "added": 30,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150601"
     },
     {
         "id": "2118920",
@@ -3627,13 +2421,7 @@
         "description": "Darryl DMC McDaniels returns and fulfills on his promise to expand the Darryl Makes Comics universe! In our second graphic novel you'll meet more heroes like LAK6, Sifu Horus, and The Breaks! They are on the cusp of...",
         "releaseDate": "2016-01-06",
         "price": "$19.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "4870425",
@@ -3645,13 +2433,7 @@
         "description": "Overview:A very impressive new series by writer/artist Darwyn Cooke! Darwyn Cooke's generations-spanning miniseries chronicling the dawn of the DC Universe's Silver Age begins here! Told from the perspective of the...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150260"
     },
     {
         "id": "7316310",
@@ -3663,13 +2445,7 @@
         "description": "World War II is over. The Cold War has begun. And the Age of the Super-hero is in decline. But where are the heroes of tomorrow? This is the opening chapter of DC: THE NEW FRONTIER, reprinted at just $1.00 with pages from...",
         "releaseDate": "2016-01-06",
         "price": "$1.00",
-        "diamondSku": "NOV150260",
-        "userMetrics": {
-            "pulled": null,
-            "added": 16,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150260"
     },
     {
         "id": "6156318",
@@ -3681,13 +2457,7 @@
         "description": "Now serving on the side of the Allies as part of the Amanda Waller’s Bombshells program, Supergirl and Stargirl wonder if they still are being used as instruments of propaganda. Meanwhile, mythological creatures and...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150253",
-        "userMetrics": {
-            "pulled": null,
-            "added": 410,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150253"
     },
     {
         "id": "4178256",
@@ -3699,13 +2469,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 8,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150883"
     },
     {
         "id": "4178256",
@@ -3717,13 +2481,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150879",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150879"
     },
     {
         "id": "4178256",
@@ -3735,13 +2493,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150882",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150882"
     },
     {
         "id": "4178256",
@@ -3753,13 +2505,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150881",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150881"
     },
     {
         "id": "4178256",
@@ -3771,13 +2517,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150880",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150880"
     },
     {
         "id": "4178256",
@@ -3789,13 +2529,7 @@
         "description": "THE MAN WHO TRAINED DAREDEVIL VS. THE WOMAN WHO LOVED DAREDEVIL! Can the blind martial arts master known as Stick beat a Bullseye who’s also his greatest student? Venom-Hulk vs Guillotines... plural? Plus! White Fox...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150878",
-        "userMetrics": {
-            "pulled": null,
-            "added": 220,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150878"
     },
     {
         "id": "9475174",
@@ -3807,13 +2541,7 @@
         "description": "What's black and white and red all over? The Deadpool Coloring Book when you've finished with it! Say goodbye to your scarlet pens and crimson pencils as you bring to life page after page of pinups featuring the claret-clad...",
         "releaseDate": "2016-01-06",
         "price": "$9.99",
-        "diamondSku": "NOV150950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 32,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150950"
     },
     {
         "id": "1390873",
@@ -3825,13 +2553,7 @@
         "description": "While New Orleans' privileged prepare to party, the city's disenfranchised batten down for the storm of the century.  But with Rosa already on the horizon, can Virgil stop the horror headed for his town before she hits?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151645",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151645"
     },
     {
         "id": "1390873",
@@ -3843,13 +2565,7 @@
         "description": "While New Orleans' privileged prepare to party, the city's disenfranchised batten down for the storm of the century.  But with Rosa already on the horizon, can Virgil stop the horror headed for his town before she hits?",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV151644",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151644"
     },
     {
         "id": "6005852",
@@ -3861,13 +2577,7 @@
         "description": "“GODWORLD,” Part Three\n\n\tA meeting with the Godhead.",
         "releaseDate": "2016-01-06",
         "price": "$3.50",
-        "diamondSku": "NOV150594",
-        "userMetrics": {
-            "pulled": null,
-            "added": 314,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 9.3
-        }
+        "diamondSku": "NOV150594"
     },
     {
         "id": "4552215",
@@ -3879,13 +2589,7 @@
         "description": "NEW STORY ARC \"Extraordinary Machine\" uncovers the past of the Bitches' secret weapon Meiko Maki, how she went from promising engineer to killer—and the ace up her sleeve. From KELLY SUE DeCONNICK (PRETTY...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150504",
-        "userMetrics": {
-            "pulled": null,
-            "added": 387,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "NOV150504"
     },
     {
         "id": "5944369",
@@ -3897,13 +2601,7 @@
         "description": "Gotham City is decending into chaos at the hands of Anarky and his quest for revenge on both the villains and protectors of the city in these tales from DETECTIVE COMICS #35-40, DETECTIVE COMICS: ENDGAME #1 and DETECTIVE...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "SEP150289",
-        "userMetrics": {
-            "pulled": null,
-            "added": 26,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150289"
     },
     {
         "id": "6266131",
@@ -3915,13 +2613,7 @@
         "description": "Batman finds himself knee-deep in a new mystery involving a deadly new narcotic in Gotham City. Can the Dark Knight stop the threat before the entire town finds itself embroiled in a deadly gang war? Collects issues #30-34...",
         "releaseDate": "2016-01-06",
         "price": "$16.99",
-        "diamondSku": "OCT150247",
-        "userMetrics": {
-            "pulled": null,
-            "added": 37,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150247"
     },
     {
         "id": "6402306",
@@ -3933,13 +2625,7 @@
         "description": "No good deed goes unpunished! Freeing the world from Brother Eye was only the beginning—with Neo-Gotham now standing as the only stable society in the known world, thousands of refugees have fled their war-torn cities...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150230",
-        "userMetrics": {
-            "pulled": null,
-            "added": 271,
-            "consensusVote": 80,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150230"
     },
     {
         "id": "3939472",
@@ -3951,13 +2637,7 @@
         "description": "Collecting the first four issues of the new series! The Joker is dead. Arkham City is closed. As a new day begins, Bruce Wayne finds himself in devastating pain, recovering from his injuries and questioning whether his role...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "OCT150245",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150245"
     },
     {
         "id": "9635447",
@@ -3969,13 +2649,7 @@
         "description": "\"Scare Tactics\" Grayson, Red Hood, Red Robin and Harper Row have uncovered the full scope of Mother’s dangerous operation, and they’re ready to spring their trap! But there’s one problem: Cassandra...",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150223",
-        "userMetrics": {
-            "pulled": null,
-            "added": 601,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150223"
     },
     {
         "id": "8687722",
@@ -3987,13 +2661,7 @@
         "description": "Shady federal agents have tasked bounty hunter Barb Wire with tracking down and delivering her former associate Avram Roman, or she’ll face dire consequences. With little choice but compliance, Barb learns that her...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150068",
-        "userMetrics": {
-            "pulled": null,
-            "added": 31,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150068"
     },
     {
         "id": "8833243",
@@ -4005,13 +2673,7 @@
         "description": "Continuing his quest to destroy the Red King, Lord Baltimore heads to the icy Baltic Sea and northern Russia, but he finds witchcraft in the streets of St. Petersburg and evil in its shadows. With new allies and fearsome...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "SEP150038",
-        "userMetrics": {
-            "pulled": null,
-            "added": 6,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150038"
     },
     {
         "id": "2548829",
@@ -4023,13 +2685,7 @@
         "description": "The first of its kind! A massive hardcover art book featuring the incredible images of Magic: The Gathering",
         "releaseDate": "2016-01-06",
         "price": "$39.99",
-        "diamondSku": "NOV151737",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151737"
     },
     {
         "id": "5453965",
@@ -4041,13 +2697,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151098",
-        "userMetrics": {
-            "pulled": null,
-            "added": 35,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151098"
     },
     {
         "id": "5453965",
@@ -4059,13 +2709,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151099",
-        "userMetrics": {
-            "pulled": null,
-            "added": 28,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT151099"
     },
     {
         "id": "5453965",
@@ -4077,13 +2721,7 @@
         "description": "The biggest comic series of the year presses on! Betty and Jughead have declared war on Veronica over the heart and soul of Archie Andrews!  Who should you be rooting for? You might just be surprised by the answer!...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT151097",
-        "userMetrics": {
-            "pulled": null,
-            "added": 301,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": 2.3
-        }
+        "diamondSku": "OCT151097"
     },
     {
         "id": "1494689",
@@ -4095,13 +2733,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150413",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150413"
     },
     {
         "id": "1494689",
@@ -4113,13 +2745,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "",
-        "diamondSku": "NOV150414",
-        "userMetrics": {
-            "pulled": null,
-            "added": 0,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150414"
     },
     {
         "id": "1494689",
@@ -4131,13 +2757,7 @@
         "description": "Angry Birds Comics returns! Just when you thought the winter doldrums were about to get you down comes a ray of comic book happiness in the form of the classic ANGRY BIRDS COMICS relaunch! Huzzah!",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150412",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150412"
     },
     {
         "id": "9162719",
@@ -4149,13 +2769,7 @@
         "description": "Faith faces off against Drusilla in a grudge match that could level Magic Town as Angel attempts to withstand Archaeus’s power over him. Meanwhile, a mysterious statue—a magical relic of great power—has...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150022",
-        "userMetrics": {
-            "pulled": null,
-            "added": 5,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150022"
     },
     {
         "id": "9162719",
@@ -4167,13 +2781,7 @@
         "description": "Faith faces off against Drusilla in a grudge match that could level Magic Town as Angel attempts to withstand Archaeus’s power over him. Meanwhile, a mysterious statue—a magical relic of great power—has...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150021",
-        "userMetrics": {
-            "pulled": null,
-            "added": 41,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150021"
     },
     {
         "id": "3924296",
@@ -4185,13 +2793,7 @@
         "description": "The End of Everything Part 1. The fifth arc of AMELIA COLE starts here, and folks, we're not gonna lie: everything's coming to a head. This is it. The stakes have never been higher. It's AMELIA COLE VERSUS THE...",
         "releaseDate": "2016-01-06",
         "price": "$0.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "8123690",
@@ -4203,13 +2805,7 @@
         "description": "The death toll mounts, and the fate of the Xenomorph that hatched from within Vampirella stands revealed! Meanwhile, the Martian Base pays the price for its mistrust of Vampirella as she and Lars deal with a horrifying threat...",
         "releaseDate": "2016-01-06",
         "price": "$50.00",
-        "diamondSku": "NOV151310",
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV151310"
     },
     {
         "id": "6714034",
@@ -4221,13 +2817,7 @@
         "description": "Ricardo Delgado's Age of Reptiles series returns and marks a bold, new direction in wordless storytelling! The steaming swamps of Cretaceous Africa teem with prehistoric life and primordial danger in a tale filled with...",
         "releaseDate": "2016-01-06",
         "price": "$14.99",
-        "diamondSku": "SEP150062",
-        "userMetrics": {
-            "pulled": null,
-            "added": 4,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "SEP150062"
     },
     {
         "id": "8938200",
@@ -4239,13 +2829,7 @@
         "description": "“The Savage Dawn” begins! Following recent events in the SUPERMAN ANNUAL, Superman is becoming increasingly desperate to regain his powers! The situation is dire, as he must rescue his fellow Justice Leaguers...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150210",
-        "userMetrics": {
-            "pulled": null,
-            "added": 29,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150210"
     },
     {
         "id": "8938200",
@@ -4257,13 +2841,7 @@
         "description": "“The Savage Dawn” begins! Following recent events in the SUPERMAN ANNUAL, Superman is becoming increasingly desperate to regain his powers! The situation is dire, as he must rescue his fellow Justice Leaguers...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "NOV150209",
-        "userMetrics": {
-            "pulled": null,
-            "added": 267,
-            "consensusVote": 90,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "NOV150209"
     },
     {
         "id": "3099238",
@@ -4275,13 +2853,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150739",
-        "userMetrics": {
-            "pulled": null,
-            "added": 18,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150739"
     },
     {
         "id": "3099238",
@@ -4293,13 +2865,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150738",
-        "userMetrics": {
-            "pulled": null,
-            "added": 11,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150738"
     },
     {
         "id": "3099238",
@@ -4311,13 +2877,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150740",
-        "userMetrics": {
-            "pulled": null,
-            "added": 12,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150740"
     },
     {
         "id": "3099238",
@@ -4329,13 +2889,7 @@
         "description": "A-FORCE, ASSEMBLE! From the ashes of Battleworld, Marvel's newest hero SINGULARITY has risen and entered the Marvel Universe. But she didn't make the journey alone. To combat the most fearsome threats from across...",
         "releaseDate": "2016-01-06",
         "price": "$3.99",
-        "diamondSku": "OCT150736",
-        "userMetrics": {
-            "pulled": null,
-            "added": 652,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": 4.7
-        }
+        "diamondSku": "OCT150736"
     },
     {
         "id": "8951361",
@@ -4347,13 +2901,7 @@
         "description": "Judge Dredd: Street Cred\n\n\tKingdom: Beast of Eden (Pt2)\n\n\tThe ABC Warriors: Return to Ro-Busters (Pt2)\n\n\tThe Order: In the Court of the Wyrmqueen (pt2)\n\n\tStrontium Dog: Repo Men (Pt2)",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 3,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": null
     },
     {
         "id": "6964720",
@@ -4365,12 +2913,6 @@
         "description": "In these stories from 100 BULLETS #59-80, the Houses of the Trust are looking for the right angle in their impending war, while the Minutemen choose sides and make their own battle plans. Then, following Lono's ascension...",
         "releaseDate": "2016-01-06",
         "price": "$24.99",
-        "diamondSku": "OCT150272",
-        "userMetrics": {
-            "pulled": null,
-            "added": 23,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "OCT150272"
     }
 ]

--- a/test/shared/pull-list/test-data/all-issues-pull-list.json
+++ b/test/shared/pull-list/test-data/all-issues-pull-list.json
@@ -9,13 +9,7 @@
         "description": "The Best Princess Ever is finally going to be chosen! Who will it be? And will the prankster finally reveal themselves before they ruin the whole event?",
         "releaseDate": "2017-05-03",
         "price": "$3.99",
-        "diamondSku": "MAR171482",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "MAR171482"
     },
     {
         "id": "8900134",
@@ -27,12 +21,6 @@
         "description": "Here comes the future!",
         "releaseDate": "2017-05-03",
         "price": "$2.99",
-        "diamondSku": "MAR170767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 615,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 8
-        }
+        "diamondSku": "MAR170767"
     }
 ]

--- a/test/shared/pull-list/test-data/filtered-issues-pull-list.json
+++ b/test/shared/pull-list/test-data/filtered-issues-pull-list.json
@@ -9,12 +9,6 @@
         "description": "Here comes the future!",
         "releaseDate": "2017-05-03",
         "price": "$2.99",
-        "diamondSku": "MAR170767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 615,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 8
-        }
+        "diamondSku": "MAR170767"
     }
 ]

--- a/test/shared/pull-list/test-data/sorted-issues-pull-list.json
+++ b/test/shared/pull-list/test-data/sorted-issues-pull-list.json
@@ -9,13 +9,7 @@
         "description": "Here comes the future!",
         "releaseDate": "2017-05-03",
         "price": "$2.99",
-        "diamondSku": "MAR170767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 615,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": 8
-        }
+        "diamondSku": "MAR170767"
     },
     {
         "id": "9302457",
@@ -27,12 +21,6 @@
         "description": "The Best Princess Ever is finally going to be chosen! Who will it be? And will the prankster finally reveal themselves before they ruin the whole event?",
         "releaseDate": "2017-05-03",
         "price": "$3.99",
-        "diamondSku": "MAR171482",
-        "userMetrics": {
-            "pulled": null,
-            "added": 27,
-            "consensusVote": null,
-            "pickOfTheWeekVote": 0
-        }
+        "diamondSku": "MAR171482"
     }
 ]

--- a/test/shared/read-list/test-data/all-issues-read-list.json
+++ b/test/shared/read-list/test-data/all-issues-read-list.json
@@ -9,13 +9,7 @@
         "description": "It's Adventure Time! Join Finn the Human, Jake the Dog, and Princess Bubblegum for all-new adventures through The Land of Ooo. The top-rated Cartoon Network show now has its own comic book! With the show exploding in the...",
         "releaseDate": "2012-02-08",
         "price": "$3.99",
-        "diamondSku": "DEC110939",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC110939"
     },
     {
         "id": "9426413",
@@ -27,13 +21,7 @@
         "description": "THERE'S NO BETTER TIME TO JUMP INTO THE ALL-AGES SENSATION! Join Jake the Dog and Finn the Human as they have sensational adventures in the magical land of Ooo! If you haven't checked out the comic book adaptation...",
         "releaseDate": "2012-11-28",
         "price": "$3.99",
-        "diamondSku": "SEP120936",
-        "userMetrics": {
-            "pulled": null,
-            "added": 60,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP120936"
     },
     {
         "id": "6782447",
@@ -45,13 +33,7 @@
         "description": "THE FINAL TOTALLY AWESOME ISSUE OF THIS ADVENTURE TIME MINI-SERIES! Can the Scream Queens rock their crazy-huge biggest gig ever...and will Princess Bubblegum finally discover the true meaning of ROCK? Final issue of this...",
         "releaseDate": "2012-12-19",
         "price": "$3.99",
-        "diamondSku": "OCT120924",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT120924"
     },
     {
         "id": "5232458",
@@ -63,13 +45,7 @@
         "description": "It's Totally Mathematical! Join Finn, Jake, and all of their friends in this second issue of the ongoing comic book series showcasing all-new adventures through the magical Land of Ooo. The boys have embarked on another...",
         "releaseDate": "2012-03-14",
         "price": "$3.99",
-        "diamondSku": "JAN120971",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN120971"
     },
     {
         "id": "3714650",
@@ -81,13 +57,7 @@
         "description": "Algebraic! Don't miss Finn, Jake, and all of their friends on their biggest adventure yet! Trapped by the dreaded Lich, the guys gotta stop all of Ooo from being sucked away forever - and rescue a bunch of wayward Princesses....",
         "releaseDate": "2012-04-11",
         "price": "$3.99",
-        "diamondSku": "FEB120869",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB120869"
     },
     {
         "id": "5195551",
@@ -99,13 +69,7 @@
         "description": "Oh My Glob! The Latest Super-Cool Issue of the Hit Series! Finn, Jake, Marceline, Princess Bubblegum and even Lumpy Space Princess have banded together to stop that jerk the Lich from throwing all of Ooo into the sun! It's...",
         "releaseDate": "2012-05-16",
         "price": "$3.99",
-        "diamondSku": "MAR120884",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR120884"
     },
     {
         "id": "7381906",
@@ -117,13 +81,7 @@
         "description": "Don't miss the beginning of the new arc of this totally rhombus series! The totally sick gang of Finn, Jake, Marceline, Princess Bubblegum, and the Ice King are back in this new arc of the incredibly popular all-ages...",
         "releaseDate": "2012-06-20",
         "price": "$3.99",
-        "diamondSku": "APR120950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR120950"
     },
     {
         "id": "2705608",
@@ -135,13 +93,7 @@
         "description": "THE FUN WILL NEVER END IN THIS HOT ALL-AGES SERIES! The awesome adventures of Finn, Jake, Marceline, Princess Bubblegum and the Ice King continue in the latest issue of this critically-acclaimed, on-going series! Demand...",
         "releaseDate": "2012-07-18",
         "price": "$3.99",
-        "diamondSku": "MAY120994",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY120994"
     },
     {
         "id": "1205249",
@@ -153,13 +105,7 @@
         "description": "JOIN JAKE THE DOG AND FINN THE HUMAN AS THE HOTTEST ALL-AGES COMIC BOOK ON THE STANDS CONTINUES! The totally mathematical adventure continues in this latest time-bending issue of ADVENTURE TIME! Order early -- issue #1 went...",
         "releaseDate": "2012-08-22",
         "price": "$3.99",
-        "diamondSku": "JUN120949",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN120949"
     },
     {
         "id": "6538129",
@@ -171,13 +117,7 @@
         "description": "THE MOST POPULAR AND TOTALLY RHOMBUS ALL-AGES COMIC ON THE STANDS TODAY! Join Jake the Dog and Finn the Human in another awesome issue of this all-ages classic! With Ooo in the grips of a Jake-caused time paradox, there's...",
         "releaseDate": "2012-09-26",
         "price": "$3.99",
-        "diamondSku": "JUL120908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL120908"
     },
     {
         "id": "2494536",
@@ -189,13 +129,7 @@
         "description": "BRAND-NEW STORY ARC! PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human as they try to right the wrongs of a Jake-caused TIME PARADOX! If you haven't checked out the comic book adaptation of the...",
         "releaseDate": "2012-10-24",
         "price": "$3.99",
-        "diamondSku": "AUG120938",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG120938"
     },
     {
         "id": "1094288",
@@ -207,13 +141,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "5900157",
@@ -225,13 +153,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "5996813",
@@ -243,13 +165,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "8972309",
@@ -261,13 +177,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "8471271",
@@ -279,13 +189,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "5947148",
@@ -297,13 +201,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8137536",
@@ -315,13 +213,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "3173369",
@@ -333,13 +225,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "1462701",
@@ -351,13 +237,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "2519140",
@@ -369,13 +249,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "3429543",
@@ -387,13 +261,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "9240446",
@@ -405,13 +273,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "4148513",
@@ -423,13 +285,7 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     },
     {
         "id": "9691807",
@@ -441,13 +297,7 @@
         "description": "A new comic miniseries based on Dan Harmon and Justin Roiland’s hilarious [adult swim] animated show Rick and Morty? Oooo-wee, that sounds great! Mr. Poopybutthole is in trouble, and he turns to the one person he can...",
         "releaseDate": "2016-07-13",
         "price": "$3.99",
-        "diamondSku": "MAY161665",
-        "userMetrics": {
-            "pulled": null,
-            "added": 124,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY161665"
     },
     {
         "id": "5988322",
@@ -459,13 +309,7 @@
         "description": "Mr. Poopybutthole lets Summer Smith in on an industry secret: that being a huge TV and movie star isn't what it's cracked up to be! He should know after all, seeing as he was this dimension's biggest Lil'...",
         "releaseDate": "2016-08-31",
         "price": "$3.99",
-        "diamondSku": "JUN161658",
-        "userMetrics": {
-            "pulled": null,
-            "added": 92,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN161658"
     },
     {
         "id": "7291412",
@@ -477,13 +321,7 @@
         "description": "Things take a turn for the worse when Summer and Mr. Poopybutthole get split up and Summer ends up in space jail! What's even up with space jail? What would Mr. Poopybutthole do? All we know is that Summer must break...",
         "releaseDate": "2016-09-21",
         "price": "$3.99",
-        "diamondSku": "JUL161784",
-        "userMetrics": {
-            "pulled": null,
-            "added": 89,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL161784"
     },
     {
         "id": "9872623",
@@ -495,13 +333,7 @@
         "description": "Mr. Poopybutthole is up to his top hat in trouble! Kidnapped and tied to a chair, Mr. Poopybutthole must negotiate with his crooked agent! Otherwise he'll get forced into a contract of being a glamorous tv/movie star...",
         "releaseDate": "2016-10-19",
         "price": "$3.99",
-        "diamondSku": "AUG161800",
-        "userMetrics": {
-            "pulled": null,
-            "added": 84,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG161800"
     },
     {
         "id": "7971730",
@@ -513,13 +345,7 @@
         "description": "It's finally the most anticipated event of the year, Prom! Mr. Poopybutthole and Summer are all dressed up and ready to unwind after a stressful adventure, but when some uninvited guests crash the party they make it...",
         "releaseDate": "2016-11-16",
         "price": "$3.99",
-        "diamondSku": "SEP161836",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161836"
     },
     {
         "id": "8374448",
@@ -531,13 +357,7 @@
         "description": "Wolverine, Deadpool, Doctor Doom, Thanos: There's one hero that's beaten them all-and now she's got her own ongoing series! (Not that she's bragging.) That's right, you asked for it, you got it, it's...",
         "releaseDate": "2015-01-07",
         "price": "$3.99",
-        "diamondSku": "NOV140732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 437,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140732"
     },
     {
         "id": "6677681",
@@ -549,13 +369,7 @@
         "description": "Starting college is hard enough, but now Squirrel Girl has to deal with Galactus too? The fate of the entire planet hangs in the balance, and only Squirrel Girl can save it! Also, her squirrel friend Tippy Toe. She can help...",
         "releaseDate": "2015-02-04",
         "price": "$3.99",
-        "diamondSku": "DEC140883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 391,
-            "consensusVote": 81,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140883"
     },
     {
         "id": "2790619",
@@ -567,13 +381,7 @@
         "description": "Time is running out, and the only way for Squirrel Girl to stop Galactus is to get to the moon... you know, somehow?? See the unveiling of Squirrel Girl's new Flying Squirrel Suit... that she maaaaybe borrowed from Iron...",
         "releaseDate": "2015-03-18",
         "price": "$3.99",
-        "diamondSku": "JAN150832",
-        "userMetrics": {
-            "pulled": null,
-            "added": 355,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150832"
     },
     {
         "id": "4859051",
@@ -585,13 +393,7 @@
         "description": "The final showdown between Galactus and Squirrel Girl is here! It's the Power Cosmic versus the Power Chestnut: WHO WILL WIN? Also, Squirrel Girl is late for class. So there's TWO disasters coming!!",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB150779",
-        "userMetrics": {
-            "pulled": null,
-            "added": 358,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150779"
     },
     {
         "id": "8229407",
@@ -603,12 +405,6 @@
         "description": "The breakout character of 2015 continues her one-woman crusade against injustice and jerks in this standalone issue, a perfect jumping-on point for new readers! These TAILS of the Squirrel Girl will show you the Marvel Universe's...",
         "releaseDate": "2015-05-06",
         "price": "$3.99",
-        "diamondSku": "MAR150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 336,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR150721"
     }
 ]

--- a/test/shared/read-list/test-data/filtered-issues-read-list.json
+++ b/test/shared/read-list/test-data/filtered-issues-read-list.json
@@ -9,13 +9,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "5900157",
@@ -27,13 +21,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "5996813",
@@ -45,13 +33,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "8972309",
@@ -63,13 +45,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "8471271",
@@ -81,13 +57,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "5947148",
@@ -99,13 +69,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8137536",
@@ -117,13 +81,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "3173369",
@@ -135,13 +93,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "1462701",
@@ -153,13 +105,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "2519140",
@@ -171,13 +117,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "3429543",
@@ -189,13 +129,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "9240446",
@@ -207,13 +141,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "4148513",
@@ -225,12 +153,6 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     }
 ]

--- a/test/shared/read-list/test-data/sorted-issues-read-list.json
+++ b/test/shared/read-list/test-data/sorted-issues-read-list.json
@@ -9,13 +9,7 @@
         "description": "The breakout character of 2015 continues her one-woman crusade against injustice and jerks in this standalone issue, a perfect jumping-on point for new readers! These TAILS of the Squirrel Girl will show you the Marvel Universe's...",
         "releaseDate": "2015-05-06",
         "price": "$3.99",
-        "diamondSku": "MAR150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 336,
-            "consensusVote": 86,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR150721"
     },
     {
         "id": "4859051",
@@ -27,13 +21,7 @@
         "description": "The final showdown between Galactus and Squirrel Girl is here! It's the Power Cosmic versus the Power Chestnut: WHO WILL WIN? Also, Squirrel Girl is late for class. So there's TWO disasters coming!!",
         "releaseDate": "2015-04-22",
         "price": "$3.99",
-        "diamondSku": "FEB150779",
-        "userMetrics": {
-            "pulled": null,
-            "added": 358,
-            "consensusVote": 91,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150779"
     },
     {
         "id": "2790619",
@@ -45,13 +33,7 @@
         "description": "Time is running out, and the only way for Squirrel Girl to stop Galactus is to get to the moon... you know, somehow?? See the unveiling of Squirrel Girl's new Flying Squirrel Suit... that she maaaaybe borrowed from Iron...",
         "releaseDate": "2015-03-18",
         "price": "$3.99",
-        "diamondSku": "JAN150832",
-        "userMetrics": {
-            "pulled": null,
-            "added": 355,
-            "consensusVote": 89,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150832"
     },
     {
         "id": "6677681",
@@ -63,13 +45,7 @@
         "description": "Starting college is hard enough, but now Squirrel Girl has to deal with Galactus too? The fate of the entire planet hangs in the balance, and only Squirrel Girl can save it! Also, her squirrel friend Tippy Toe. She can help...",
         "releaseDate": "2015-02-04",
         "price": "$3.99",
-        "diamondSku": "DEC140883",
-        "userMetrics": {
-            "pulled": null,
-            "added": 391,
-            "consensusVote": 81,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140883"
     },
     {
         "id": "8374448",
@@ -81,13 +57,7 @@
         "description": "Wolverine, Deadpool, Doctor Doom, Thanos: There's one hero that's beaten them all-and now she's got her own ongoing series! (Not that she's bragging.) That's right, you asked for it, you got it, it's...",
         "releaseDate": "2015-01-07",
         "price": "$3.99",
-        "diamondSku": "NOV140732",
-        "userMetrics": {
-            "pulled": null,
-            "added": 437,
-            "consensusVote": 82,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140732"
     },
     {
         "id": "7971730",
@@ -99,13 +69,7 @@
         "description": "It's finally the most anticipated event of the year, Prom! Mr. Poopybutthole and Summer are all dressed up and ready to unwind after a stressful adventure, but when some uninvited guests crash the party they make it...",
         "releaseDate": "2016-11-16",
         "price": "$3.99",
-        "diamondSku": "SEP161836",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161836"
     },
     {
         "id": "9872623",
@@ -117,13 +81,7 @@
         "description": "Mr. Poopybutthole is up to his top hat in trouble! Kidnapped and tied to a chair, Mr. Poopybutthole must negotiate with his crooked agent! Otherwise he'll get forced into a contract of being a glamorous tv/movie star...",
         "releaseDate": "2016-10-19",
         "price": "$3.99",
-        "diamondSku": "AUG161800",
-        "userMetrics": {
-            "pulled": null,
-            "added": 84,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG161800"
     },
     {
         "id": "7291412",
@@ -135,13 +93,7 @@
         "description": "Things take a turn for the worse when Summer and Mr. Poopybutthole get split up and Summer ends up in space jail! What's even up with space jail? What would Mr. Poopybutthole do? All we know is that Summer must break...",
         "releaseDate": "2016-09-21",
         "price": "$3.99",
-        "diamondSku": "JUL161784",
-        "userMetrics": {
-            "pulled": null,
-            "added": 89,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL161784"
     },
     {
         "id": "5988322",
@@ -153,13 +105,7 @@
         "description": "Mr. Poopybutthole lets Summer Smith in on an industry secret: that being a huge TV and movie star isn't what it's cracked up to be! He should know after all, seeing as he was this dimension's biggest Lil'...",
         "releaseDate": "2016-08-31",
         "price": "$3.99",
-        "diamondSku": "JUN161658",
-        "userMetrics": {
-            "pulled": null,
-            "added": 92,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN161658"
     },
     {
         "id": "9691807",
@@ -171,13 +117,7 @@
         "description": "A new comic miniseries based on Dan Harmon and Justin Roiland’s hilarious [adult swim] animated show Rick and Morty? Oooo-wee, that sounds great! Mr. Poopybutthole is in trouble, and he turns to the one person he can...",
         "releaseDate": "2016-07-13",
         "price": "$3.99",
-        "diamondSku": "MAY161665",
-        "userMetrics": {
-            "pulled": null,
-            "added": 124,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY161665"
     },
     {
         "id": "4148513",
@@ -189,13 +129,7 @@
         "description": "The future collides with the past in our present- day 2016, and the Paper Girls must make a difficult decision about who to trust.",
         "releaseDate": "2016-09-07",
         "price": "$2.99",
-        "diamondSku": "JUL160767",
-        "userMetrics": {
-            "pulled": null,
-            "added": 804,
-            "consensusVote": 94,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160767"
     },
     {
         "id": "9240446",
@@ -207,13 +141,7 @@
         "description": "Three young heroes from 1988 have been catapulted to the twenty-first century, and to make matters worse, something horrible has followed them there.",
         "releaseDate": "2016-08-03",
         "price": "$2.99",
-        "diamondSku": "JUN160647",
-        "userMetrics": {
-            "pulled": null,
-            "added": 840,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160647"
     },
     {
         "id": "3429543",
@@ -225,13 +153,7 @@
         "description": "Trapped in a dark future, Erin and her fellow deliverers from 1988 uncover shocking truths about their own fates.",
         "releaseDate": "2016-07-06",
         "price": "$2.99",
-        "diamondSku": "MAY160649",
-        "userMetrics": {
-            "pulled": null,
-            "added": 891,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY160649"
     },
     {
         "id": "2519140",
@@ -243,13 +165,7 @@
         "description": "The smash-hit ongoing series returns with a bold new direction, as Erin, Mac, and Tiffany find themselves launched from 1988 to a distant and terrifying future.",
         "releaseDate": "2016-06-01",
         "price": "$2.99",
-        "diamondSku": "APR160718",
-        "userMetrics": {
-            "pulled": null,
-            "added": 933,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR160718"
     },
     {
         "id": "1462701",
@@ -261,13 +177,7 @@
         "description": "The first arc of the smash-hit ongoing series concludes with major revelations and another game-changing cliffhanger.",
         "releaseDate": "2016-02-03",
         "price": "$2.99",
-        "diamondSku": "DEC150603",
-        "userMetrics": {
-            "pulled": null,
-            "added": 995,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC150603"
     },
     {
         "id": "3173369",
@@ -279,13 +189,7 @@
         "description": "What lurks beneath the streets of Stony Stream?",
         "releaseDate": "2016-01-06",
         "price": "$2.99",
-        "diamondSku": "NOV150626",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1041,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV150626"
     },
     {
         "id": "8137536",
@@ -297,13 +201,7 @@
         "description": "The ongoing mystery series from BRIAN K. VAUGHAN & CLIFF CHIANG charges ahead, as the girls have a close encounter with an unexpected visitor.",
         "releaseDate": "2015-12-02",
         "price": "$2.99",
-        "diamondSku": "OCT150500",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1094,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT150500"
     },
     {
         "id": "5947148",
@@ -315,13 +213,7 @@
         "description": "The hottest new ongoing series of the year continues, as the Paper Girls witness the impossible.",
         "releaseDate": "2015-11-04",
         "price": "$2.99",
-        "diamondSku": "SEP150512",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1175,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP150512"
     },
     {
         "id": "8471271",
@@ -333,13 +225,7 @@
         "description": "Trapped in the distant past, KJ discovers something shocking about the future.",
         "releaseDate": "2017-04-05",
         "price": "$2.99",
-        "diamondSku": "FEB170668",
-        "userMetrics": {
-            "pulled": null,
-            "added": 621,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170668"
     },
     {
         "id": "8972309",
@@ -351,13 +237,7 @@
         "description": "Growing up can be deadly.",
         "releaseDate": "2017-03-01",
         "price": "$2.99",
-        "diamondSku": "JAN170750",
-        "userMetrics": {
-            "pulled": null,
-            "added": 648,
-            "consensusVote": 95,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN170750"
     },
     {
         "id": "5996813",
@@ -369,13 +249,7 @@
         "description": "A BOLD NEW STORYLINE STARTS HERE! The Eisner and Harvey Award-winning “Best New Series\" from BRIAN K. VAUGHAN andCLIFF CHIANG returns, as Erin, Mac, and Tiffany finally reunite with their long-lost friend KJ…only...",
         "releaseDate": "2017-02-01",
         "price": "$2.99",
-        "diamondSku": "DEC160678",
-        "userMetrics": {
-            "pulled": null,
-            "added": 689,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC160678"
     },
     {
         "id": "5900157",
@@ -387,13 +261,7 @@
         "description": "The second arc of the smash-hit ongoing series concludes with the Paper Girls risking everything to escape the 21st Century… but if any survive, where will they end up next?",
         "releaseDate": "2016-10-05",
         "price": "$2.99",
-        "diamondSku": "AUG160651",
-        "userMetrics": {
-            "pulled": null,
-            "added": 782,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160651"
     },
     {
         "id": "1094288",
@@ -405,13 +273,7 @@
         "description": "SAGA writer BRIAN K. VAUGHAN launches a brand-new ONGOING SERIES with superstar Wonder Woman artist CLIFF CHIANG! In the early hours after Halloween of 1988, four 12-year-old newspaper delivery girls uncover the most important...",
         "releaseDate": "2015-10-07",
         "price": "$2.99",
-        "diamondSku": "AUG150476",
-        "userMetrics": {
-            "pulled": null,
-            "added": 1368,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG150476"
     },
     {
         "id": "2494536",
@@ -423,13 +285,7 @@
         "description": "BRAND-NEW STORY ARC! PERFECT JUMPING-ON POINT FOR NEW READERS! Join Jake the Dog and Finn the Human as they try to right the wrongs of a Jake-caused TIME PARADOX! If you haven't checked out the comic book adaptation of the...",
         "releaseDate": "2012-10-24",
         "price": "$3.99",
-        "diamondSku": "AUG120938",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG120938"
     },
     {
         "id": "6538129",
@@ -441,13 +297,7 @@
         "description": "THE MOST POPULAR AND TOTALLY RHOMBUS ALL-AGES COMIC ON THE STANDS TODAY! Join Jake the Dog and Finn the Human in another awesome issue of this all-ages classic! With Ooo in the grips of a Jake-caused time paradox, there's...",
         "releaseDate": "2012-09-26",
         "price": "$3.99",
-        "diamondSku": "JUL120908",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL120908"
     },
     {
         "id": "1205249",
@@ -459,13 +309,7 @@
         "description": "JOIN JAKE THE DOG AND FINN THE HUMAN AS THE HOTTEST ALL-AGES COMIC BOOK ON THE STANDS CONTINUES! The totally mathematical adventure continues in this latest time-bending issue of ADVENTURE TIME! Order early -- issue #1 went...",
         "releaseDate": "2012-08-22",
         "price": "$3.99",
-        "diamondSku": "JUN120949",
-        "userMetrics": {
-            "pulled": null,
-            "added": 80,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN120949"
     },
     {
         "id": "2705608",
@@ -477,13 +321,7 @@
         "description": "THE FUN WILL NEVER END IN THIS HOT ALL-AGES SERIES! The awesome adventures of Finn, Jake, Marceline, Princess Bubblegum and the Ice King continue in the latest issue of this critically-acclaimed, on-going series! Demand...",
         "releaseDate": "2012-07-18",
         "price": "$3.99",
-        "diamondSku": "MAY120994",
-        "userMetrics": {
-            "pulled": null,
-            "added": 67,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY120994"
     },
     {
         "id": "7381906",
@@ -495,13 +333,7 @@
         "description": "Don't miss the beginning of the new arc of this totally rhombus series! The totally sick gang of Finn, Jake, Marceline, Princess Bubblegum, and the Ice King are back in this new arc of the incredibly popular all-ages...",
         "releaseDate": "2012-06-20",
         "price": "$3.99",
-        "diamondSku": "APR120950",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR120950"
     },
     {
         "id": "5195551",
@@ -513,13 +345,7 @@
         "description": "Oh My Glob! The Latest Super-Cool Issue of the Hit Series! Finn, Jake, Marceline, Princess Bubblegum and even Lumpy Space Princess have banded together to stop that jerk the Lich from throwing all of Ooo into the sun! It's...",
         "releaseDate": "2012-05-16",
         "price": "$3.99",
-        "diamondSku": "MAR120884",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAR120884"
     },
     {
         "id": "3714650",
@@ -531,13 +357,7 @@
         "description": "Algebraic! Don't miss Finn, Jake, and all of their friends on their biggest adventure yet! Trapped by the dreaded Lich, the guys gotta stop all of Ooo from being sucked away forever - and rescue a bunch of wayward Princesses....",
         "releaseDate": "2012-04-11",
         "price": "$3.99",
-        "diamondSku": "FEB120869",
-        "userMetrics": {
-            "pulled": null,
-            "added": 76,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB120869"
     },
     {
         "id": "5232458",
@@ -549,13 +369,7 @@
         "description": "It's Totally Mathematical! Join Finn, Jake, and all of their friends in this second issue of the ongoing comic book series showcasing all-new adventures through the magical Land of Ooo. The boys have embarked on another...",
         "releaseDate": "2012-03-14",
         "price": "$3.99",
-        "diamondSku": "JAN120971",
-        "userMetrics": {
-            "pulled": null,
-            "added": 71,
-            "consensusVote": 84,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN120971"
     },
     {
         "id": "6782447",
@@ -567,13 +381,7 @@
         "description": "THE FINAL TOTALLY AWESOME ISSUE OF THIS ADVENTURE TIME MINI-SERIES! Can the Scream Queens rock their crazy-huge biggest gig ever...and will Princess Bubblegum finally discover the true meaning of ROCK? Final issue of this...",
         "releaseDate": "2012-12-19",
         "price": "$3.99",
-        "diamondSku": "OCT120924",
-        "userMetrics": {
-            "pulled": null,
-            "added": 72,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT120924"
     },
     {
         "id": "9426413",
@@ -585,13 +393,7 @@
         "description": "THERE'S NO BETTER TIME TO JUMP INTO THE ALL-AGES SENSATION! Join Jake the Dog and Finn the Human as they have sensational adventures in the magical land of Ooo! If you haven't checked out the comic book adaptation...",
         "releaseDate": "2012-11-28",
         "price": "$3.99",
-        "diamondSku": "SEP120936",
-        "userMetrics": {
-            "pulled": null,
-            "added": 60,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP120936"
     },
     {
         "id": "4281652",
@@ -603,12 +405,6 @@
         "description": "It's Adventure Time! Join Finn the Human, Jake the Dog, and Princess Bubblegum for all-new adventures through The Land of Ooo. The top-rated Cartoon Network show now has its own comic book! With the show exploding in the...",
         "releaseDate": "2012-02-08",
         "price": "$3.99",
-        "diamondSku": "DEC110939",
-        "userMetrics": {
-            "pulled": null,
-            "added": 78,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC110939"
     }
 ]

--- a/test/shared/search-results/test-data/all-issues-seduction-of-the-innocent.json
+++ b/test/shared/search-results/test-data/all-issues-seduction-of-the-innocent.json
@@ -9,13 +9,7 @@
         "description": "San Francisco, 1953. FBI Agent Thomas Jennings has just arrived in the city, fresh-faced and ready to tackle crime in the big city… he thinks. In fact, Jennings is not nearly prepared for what he's about to encounter....",
         "releaseDate": "2015-12-02",
         "price": "$3.99",
-        "diamondSku": "OCT151315",
-        "userMetrics": {
-            "pulled": null,
-            "added": 34,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT151315"
     },
     {
         "id": "3290550",
@@ -27,13 +21,7 @@
         "description": "Reprints from Adventures into Darkness #6, Out of the Shadows #7, Fantastic Worlds #7, Out of the Shadows #9",
         "releaseDate": "1985-10-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "9638055",
@@ -45,13 +33,7 @@
         "description": "San Francisco, 1953. F.B.I. Agent Thomas Jennings has been in town all of forty-eight hours. He's been stabbed, chased, and betrayed, witnessing more horrors than he ever could have imagined. Now, in a desperate race...",
         "releaseDate": "2015-12-30",
         "price": "$3.99",
-        "diamondSku": "NOV151304",
-        "userMetrics": {
-            "pulled": null,
-            "added": 22,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV151304"
     },
     {
         "id": "1711123",
@@ -63,13 +45,7 @@
         "description": "Reprints from Adventures Into Darkness #5 & #7, Fantastic Worlds #5",
         "releaseDate": "1985-11-04",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "8546782",
@@ -81,13 +57,7 @@
         "description": "The streets of 1953 San Francisco are overflowing with blood, as a pair of ghastly killers continue to terrorize the city. FBI Agent Thomas Jennings has his hands full at his new post. He's got to find two lost children...",
         "releaseDate": "2016-02-03",
         "price": "$3.99",
-        "diamondSku": "DEC151246",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC151246"
     },
     {
         "id": "2759862",
@@ -99,13 +69,7 @@
         "description": "Reprints from Who Is Next? #5, The Unseen #10, Out of the Shadows #14, Adventures Into Darkness #6, Lost Worlds #5",
         "releaseDate": "1985-12-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "7121846",
@@ -117,13 +81,7 @@
         "description": "In his first week on the job, FBI Agent Thomas Jennings has seen enough horror to threaten his faith, and perhaps his sanity. Now he stands alone - the last line of defense against a madman intent on the murder of two innocent...",
         "releaseDate": "2016-03-02",
         "price": "$3.99",
-        "diamondSku": "JAN161376",
-        "userMetrics": {
-            "pulled": null,
-            "added": 20,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN161376"
     },
     {
         "id": "5769576",
@@ -135,13 +93,7 @@
         "description": "Reprints from Out Of The Shadows #12, Tales Of Horror #7, Mr. Mystery #8, Lost Worlds #5",
         "releaseDate": "1986-02-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "7001527",
@@ -153,13 +105,7 @@
         "description": "Reprints from Out Of The Shadows #6, Adventures Into Darkness #7, The Unseen #12, Out Of The Shadows #8",
         "releaseDate": "1986-03-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "8545980",
@@ -171,13 +117,7 @@
         "description": "Series continues, cross-listed as Christmas Classics (Walt Kelly’s…) #1, other titles from Eclipse; Reprints from Adventures Into Darkness #9, The Unseen #9 & #12, Out Of The Shadows #8",
         "releaseDate": "1986-04-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "1656949",
@@ -189,13 +129,7 @@
         "description": "Reprints from Adventures Into Darkness #15",
         "releaseDate": "1985-10-01",
         "price": "$2.25",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "1166825",
@@ -207,13 +141,7 @@
         "description": "Reprints from Journey into Fear #1, Weird Mysteries #7, Adventures into Darkness #11, Adventures into Darkness #13, Out of the Shadows #12",
         "releaseDate": "1986-04-01",
         "price": "$2.25",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "6220738",
@@ -225,12 +153,6 @@
         "description": "Volume 1 - 1st printing. Collects Seduction of the Innocent (2015 Dynamite) #1-4. Written by Ande Parks. Art by Esteve Polls. Cover by Francesco Francavilla. FBI Agent Thomas Jennings has just arrived in San Francisco, fresh-faced...",
         "releaseDate": "2016-08-29",
         "price": "$15.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     }
 ]

--- a/test/shared/search-results/test-data/filtered-issues-seduction-of-the-innocent.json
+++ b/test/shared/search-results/test-data/filtered-issues-seduction-of-the-innocent.json
@@ -9,13 +9,7 @@
         "description": "San Francisco, 1953. FBI Agent Thomas Jennings has just arrived in the city, fresh-faced and ready to tackle crime in the big city… he thinks. In fact, Jennings is not nearly prepared for what he's about to encounter....",
         "releaseDate": "2015-12-02",
         "price": "$3.99",
-        "diamondSku": "OCT151315",
-        "userMetrics": {
-            "pulled": null,
-            "added": 34,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT151315"
     },
     {
         "id": "9638055",
@@ -27,13 +21,7 @@
         "description": "San Francisco, 1953. F.B.I. Agent Thomas Jennings has been in town all of forty-eight hours. He's been stabbed, chased, and betrayed, witnessing more horrors than he ever could have imagined. Now, in a desperate race...",
         "releaseDate": "2015-12-30",
         "price": "$3.99",
-        "diamondSku": "NOV151304",
-        "userMetrics": {
-            "pulled": null,
-            "added": 22,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV151304"
     },
     {
         "id": "8546782",
@@ -45,13 +33,7 @@
         "description": "The streets of 1953 San Francisco are overflowing with blood, as a pair of ghastly killers continue to terrorize the city. FBI Agent Thomas Jennings has his hands full at his new post. He's got to find two lost children...",
         "releaseDate": "2016-02-03",
         "price": "$3.99",
-        "diamondSku": "DEC151246",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC151246"
     },
     {
         "id": "7121846",
@@ -63,13 +45,7 @@
         "description": "In his first week on the job, FBI Agent Thomas Jennings has seen enough horror to threaten his faith, and perhaps his sanity. Now he stands alone - the last line of defense against a madman intent on the murder of two innocent...",
         "releaseDate": "2016-03-02",
         "price": "$3.99",
-        "diamondSku": "JAN161376",
-        "userMetrics": {
-            "pulled": null,
-            "added": 20,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN161376"
     },
     {
         "id": "6220738",
@@ -81,12 +57,6 @@
         "description": "Volume 1 - 1st printing. Collects Seduction of the Innocent (2015 Dynamite) #1-4. Written by Ande Parks. Art by Esteve Polls. Cover by Francesco Francavilla. FBI Agent Thomas Jennings has just arrived in San Francisco, fresh-faced...",
         "releaseDate": "2016-08-29",
         "price": "$15.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     }
 ]

--- a/test/shared/search-results/test-data/sorted-issues-seduction-of-the-innocent.json
+++ b/test/shared/search-results/test-data/sorted-issues-seduction-of-the-innocent.json
@@ -9,13 +9,7 @@
         "description": "Volume 1 - 1st printing. Collects Seduction of the Innocent (2015 Dynamite) #1-4. Written by Ande Parks. Art by Esteve Polls. Cover by Francesco Francavilla. FBI Agent Thomas Jennings has just arrived in San Francisco, fresh-faced...",
         "releaseDate": "2016-08-29",
         "price": "$15.99",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "1166825",
@@ -27,13 +21,7 @@
         "description": "Reprints from Journey into Fear #1, Weird Mysteries #7, Adventures into Darkness #11, Adventures into Darkness #13, Out of the Shadows #12",
         "releaseDate": "1986-04-01",
         "price": "$2.25",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "1656949",
@@ -45,13 +33,7 @@
         "description": "Reprints from Adventures Into Darkness #15",
         "releaseDate": "1985-10-01",
         "price": "$2.25",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "8545980",
@@ -63,13 +45,7 @@
         "description": "Series continues, cross-listed as Christmas Classics (Walt Kelly’s…) #1, other titles from Eclipse; Reprints from Adventures Into Darkness #9, The Unseen #9 & #12, Out Of The Shadows #8",
         "releaseDate": "1986-04-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "7001527",
@@ -81,13 +57,7 @@
         "description": "Reprints from Out Of The Shadows #6, Adventures Into Darkness #7, The Unseen #12, Out Of The Shadows #8",
         "releaseDate": "1986-03-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "7121846",
@@ -99,13 +69,7 @@
         "description": "In his first week on the job, FBI Agent Thomas Jennings has seen enough horror to threaten his faith, and perhaps his sanity. Now he stands alone - the last line of defense against a madman intent on the murder of two innocent...",
         "releaseDate": "2016-03-02",
         "price": "$3.99",
-        "diamondSku": "JAN161376",
-        "userMetrics": {
-            "pulled": null,
-            "added": 20,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN161376"
     },
     {
         "id": "5769576",
@@ -117,13 +81,7 @@
         "description": "Reprints from Out Of The Shadows #12, Tales Of Horror #7, Mr. Mystery #8, Lost Worlds #5",
         "releaseDate": "1986-02-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "8546782",
@@ -135,13 +93,7 @@
         "description": "The streets of 1953 San Francisco are overflowing with blood, as a pair of ghastly killers continue to terrorize the city. FBI Agent Thomas Jennings has his hands full at his new post. He's got to find two lost children...",
         "releaseDate": "2016-02-03",
         "price": "$3.99",
-        "diamondSku": "DEC151246",
-        "userMetrics": {
-            "pulled": null,
-            "added": 19,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC151246"
     },
     {
         "id": "2759862",
@@ -153,13 +105,7 @@
         "description": "Reprints from Who Is Next? #5, The Unseen #10, Out of the Shadows #14, Adventures Into Darkness #6, Lost Worlds #5",
         "releaseDate": "1985-12-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "9638055",
@@ -171,13 +117,7 @@
         "description": "San Francisco, 1953. F.B.I. Agent Thomas Jennings has been in town all of forty-eight hours. He's been stabbed, chased, and betrayed, witnessing more horrors than he ever could have imagined. Now, in a desperate race...",
         "releaseDate": "2015-12-30",
         "price": "$3.99",
-        "diamondSku": "NOV151304",
-        "userMetrics": {
-            "pulled": null,
-            "added": 22,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV151304"
     },
     {
         "id": "1711123",
@@ -189,13 +129,7 @@
         "description": "Reprints from Adventures Into Darkness #5 & #7, Fantastic Worlds #5",
         "releaseDate": "1985-11-04",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 2,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     },
     {
         "id": "1819483",
@@ -207,13 +141,7 @@
         "description": "San Francisco, 1953. FBI Agent Thomas Jennings has just arrived in the city, fresh-faced and ready to tackle crime in the big city… he thinks. In fact, Jennings is not nearly prepared for what he's about to encounter....",
         "releaseDate": "2015-12-02",
         "price": "$3.99",
-        "diamondSku": "OCT151315",
-        "userMetrics": {
-            "pulled": null,
-            "added": 34,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT151315"
     },
     {
         "id": "3290550",
@@ -225,12 +153,6 @@
         "description": "Reprints from Adventures into Darkness #6, Out of the Shadows #7, Fantastic Worlds #7, Out of the Shadows #9",
         "releaseDate": "1985-10-01",
         "price": "$1.75",
-        "diamondSku": null,
-        "userMetrics": {
-            "pulled": null,
-            "added": 1,
-            "consensusVote": null,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": null
     }
 ]

--- a/test/shared/wish-list/test-data/all-issues-wish-list.json
+++ b/test/shared/wish-list/test-data/all-issues-wish-list.json
@@ -9,13 +9,7 @@
         "description": "SERIES PREMIERE Zelda was born in a world of dreams, and hers burned bigger than anyone had ever seen. Now she's on the run in our world, the dreams broken in her hands. But the pieces are for sale, the rich and the...",
         "releaseDate": "2017-04-05",
         "price": "$3.99",
-        "diamondSku": "FEB170540",
-        "userMetrics": {
-            "pulled": null,
-            "added": 245,
-            "consensusVote": 83,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170540"
     },
     {
         "id": "6146985",
@@ -27,13 +21,7 @@
         "description": "In case you've been living under a rock, Tsum Tsums are HUGE! Well, not LITERALLY (they're actually pretty tiny) but these seemingly cute and cuddly creatures are sweeping the globe! So what happens when these pint-sized...",
         "releaseDate": "2016-08-03",
         "price": "$3.99",
-        "diamondSku": "JUN160823",
-        "userMetrics": {
-            "pulled": null,
-            "added": 102,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160823"
     },
     {
         "id": "6157347",
@@ -45,13 +33,7 @@
         "description": "THE VILLAINOUS TSUM TSUMS MAKE THEIR PRESENCE KNOWN!\n\n\t\n\t\tStill learning about Earth, some of the Tsum Tsums take inspiration fromthe less noble superhumans…and cause about as much mayhem!",
         "releaseDate": "2016-09-07",
         "price": "$3.99",
-        "diamondSku": "JUL160965",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160965"
     },
     {
         "id": "7383614",
@@ -63,13 +45,7 @@
         "description": "TSUM TSUM CIVIL WAR?!  The Tsum Tsums square off with foes you'd never expect - including each other!",
         "releaseDate": "2016-10-26",
         "price": "$3.99",
-        "diamondSku": "AUG160957",
-        "userMetrics": {
-            "pulled": null,
-            "added": 63,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160957"
     },
     {
         "id": "6262600",
@@ -81,13 +57,7 @@
         "description": "HERE COMES THE TSUM! The worldwide phenomenon comes to a close with a bang! Will the Tsum Tsum make it out of their trip to Earth?! And! What will be the fate of the children living in THE BLOCK when Ultron returns?!",
         "releaseDate": "2016-11-23",
         "price": "$3.99",
-        "diamondSku": "SEP161099",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161099"
     },
     {
         "id": "5765063",
@@ -99,13 +69,7 @@
         "description": "Dan Harmon & Justin Roiland's hilarious hit Adult Swim animated show RICK & MORTY now has its own comic book series from Oni Press! Join degenerate superscientist Rick Sanchez as he embarks on all-new insane adventures with...",
         "releaseDate": "2015-04-01",
         "price": "$3.99",
-        "diamondSku": "FEB151518",
-        "userMetrics": {
-            "pulled": null,
-            "added": 251,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB151518"
     },
     {
         "id": "9999868",
@@ -117,13 +81,7 @@
         "description": "Every ninety years, twelve gods incarnate as teenagers. They are loved. They are hated. In two years, they are dead. The team behind critically thermonuclear floor-fillers Young Avengers and PHONOGRAM reunite to start a...",
         "releaseDate": "2014-06-18",
         "price": "$3.50",
-        "diamondSku": "APR140486",
-        "userMetrics": {
-            "pulled": null,
-            "added": 677,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR140486"
     },
     {
         "id": "9736983",
@@ -135,13 +93,7 @@
         "description": "Ragnarock is finally here. The show to end all shows promises to be a lovely experience for all the gods... wait. Oh noes! Jamie and Matt have drawn Baphomet drenched in blood on the cover. What a hilarious internal communication...",
         "releaseDate": "2015-05-06",
         "price": "$3.50",
-        "diamondSku": "FEB150648",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150648"
     },
     {
         "id": "2359884",
@@ -153,13 +105,7 @@
         "description": "Diabolically divine pop-god Lucifer is in trouble. She offers superfan Laura an unprecedented deal if she helps. It's a bargain. A Faustian bargain, and they always turn out so well. Who knows who Laura will turn to...",
         "releaseDate": "2014-07-16",
         "price": "$3.50",
-        "diamondSku": "MAY140745",
-        "userMetrics": {
-            "pulled": null,
-            "added": 645,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY140745"
     },
     {
         "id": "7937806",
@@ -171,13 +117,7 @@
         "description": "Laura has no choice. She has to go underground to find the goth-goth-gothity-goth of the Morrigan. Is this the most ill-advised underworld-related decision since Orpheus decided to see how Eurydice was doing in the back...",
         "releaseDate": "2014-08-20",
         "price": "$3.50",
-        "diamondSku": "JUN140587",
-        "userMetrics": {
-            "pulled": null,
-            "added": 639,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN140587"
     },
     {
         "id": "5518869",
@@ -189,13 +129,7 @@
         "description": "The mystery is solved. But does pop-god Lucifer like the answer? The answer is a word that rhymes with \"Go\", \"Blow\" and \"Pro\". If you think the answer rhymes with \"Cow\" I applaud you...",
         "releaseDate": "2014-09-17",
         "price": "$3.50",
-        "diamondSku": "JUL140590",
-        "userMetrics": {
-            "pulled": null,
-            "added": 618,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL140590"
     },
     {
         "id": "2489507",
@@ -207,13 +141,7 @@
         "description": "Showtime.",
         "releaseDate": "2014-10-22",
         "price": "$3.50",
-        "diamondSku": "AUG140694",
-        "userMetrics": {
-            "pulled": null,
-            "added": 607,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG140694"
     },
     {
         "id": "9626603",
@@ -225,13 +153,7 @@
         "description": "THE FAUST ACT is over. Welcome to FANDEMONIUM. The second arc of THE WICKED + THE DIVINE begins in its traditional manner (i.e. a ludicrous pun.) We'd say something like 'nothing will ever be the same again'...",
         "releaseDate": "2014-12-17",
         "price": "$3.50",
-        "diamondSku": "OCT140611",
-        "userMetrics": {
-            "pulled": null,
-            "added": 602,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT140611"
     },
     {
         "id": "3056913",
@@ -243,13 +165,7 @@
         "description": "Last year, before The Recurrence, fans gathered from their lonely worlds at RAGNAROCK to wonder whether the gods were really about to return or not. Now, as the next RAGNAROCK approaches, everyone knows things are different....",
         "releaseDate": "2015-01-21",
         "price": "$3.50",
-        "diamondSku": "NOV140697",
-        "userMetrics": {
-            "pulled": null,
-            "added": 552,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140697"
     },
     {
         "id": "6297602",
@@ -261,13 +177,7 @@
         "description": "Now the eleventh god is here, it's time to party. You're invited. Everyone's invited. We can sleep when we're dead—but when you'll be dead within two years, you may as well turn up in your pyjamas....",
         "releaseDate": "2015-02-25",
         "price": "$3.50",
-        "diamondSku": "DEC140772",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140772"
     },
     {
         "id": "3879401",
@@ -279,12 +189,6 @@
         "description": "It's time for a private audience with Ananke, she who has protected and judged the Pantheon for thousands of years. Yes, it's time for an interview... with an umpire. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes....",
         "releaseDate": "2015-03-25",
         "price": "$3.50",
-        "diamondSku": "JAN150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 548,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150721"
     }
 ]

--- a/test/shared/wish-list/test-data/filtered-issues-wish-list.json
+++ b/test/shared/wish-list/test-data/filtered-issues-wish-list.json
@@ -9,13 +9,7 @@
         "description": "SERIES PREMIERE Zelda was born in a world of dreams, and hers burned bigger than anyone had ever seen. Now she's on the run in our world, the dreams broken in her hands. But the pieces are for sale, the rich and the...",
         "releaseDate": "2017-04-05",
         "price": "$3.99",
-        "diamondSku": "FEB170540",
-        "userMetrics": {
-            "pulled": null,
-            "added": 245,
-            "consensusVote": 83,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170540"
     },
     {
         "id": "9999868",
@@ -27,13 +21,7 @@
         "description": "Every ninety years, twelve gods incarnate as teenagers. They are loved. They are hated. In two years, they are dead. The team behind critically thermonuclear floor-fillers Young Avengers and PHONOGRAM reunite to start a...",
         "releaseDate": "2014-06-18",
         "price": "$3.50",
-        "diamondSku": "APR140486",
-        "userMetrics": {
-            "pulled": null,
-            "added": 677,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR140486"
     },
     {
         "id": "9736983",
@@ -45,13 +33,7 @@
         "description": "Ragnarock is finally here. The show to end all shows promises to be a lovely experience for all the gods... wait. Oh noes! Jamie and Matt have drawn Baphomet drenched in blood on the cover. What a hilarious internal communication...",
         "releaseDate": "2015-05-06",
         "price": "$3.50",
-        "diamondSku": "FEB150648",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150648"
     },
     {
         "id": "2359884",
@@ -63,13 +45,7 @@
         "description": "Diabolically divine pop-god Lucifer is in trouble. She offers superfan Laura an unprecedented deal if she helps. It's a bargain. A Faustian bargain, and they always turn out so well. Who knows who Laura will turn to...",
         "releaseDate": "2014-07-16",
         "price": "$3.50",
-        "diamondSku": "MAY140745",
-        "userMetrics": {
-            "pulled": null,
-            "added": 645,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY140745"
     },
     {
         "id": "7937806",
@@ -81,13 +57,7 @@
         "description": "Laura has no choice. She has to go underground to find the goth-goth-gothity-goth of the Morrigan. Is this the most ill-advised underworld-related decision since Orpheus decided to see how Eurydice was doing in the back...",
         "releaseDate": "2014-08-20",
         "price": "$3.50",
-        "diamondSku": "JUN140587",
-        "userMetrics": {
-            "pulled": null,
-            "added": 639,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN140587"
     },
     {
         "id": "5518869",
@@ -99,13 +69,7 @@
         "description": "The mystery is solved. But does pop-god Lucifer like the answer? The answer is a word that rhymes with \"Go\", \"Blow\" and \"Pro\". If you think the answer rhymes with \"Cow\" I applaud you...",
         "releaseDate": "2014-09-17",
         "price": "$3.50",
-        "diamondSku": "JUL140590",
-        "userMetrics": {
-            "pulled": null,
-            "added": 618,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL140590"
     },
     {
         "id": "2489507",
@@ -117,13 +81,7 @@
         "description": "Showtime.",
         "releaseDate": "2014-10-22",
         "price": "$3.50",
-        "diamondSku": "AUG140694",
-        "userMetrics": {
-            "pulled": null,
-            "added": 607,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG140694"
     },
     {
         "id": "9626603",
@@ -135,13 +93,7 @@
         "description": "THE FAUST ACT is over. Welcome to FANDEMONIUM. The second arc of THE WICKED + THE DIVINE begins in its traditional manner (i.e. a ludicrous pun.) We'd say something like 'nothing will ever be the same again'...",
         "releaseDate": "2014-12-17",
         "price": "$3.50",
-        "diamondSku": "OCT140611",
-        "userMetrics": {
-            "pulled": null,
-            "added": 602,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT140611"
     },
     {
         "id": "3056913",
@@ -153,13 +105,7 @@
         "description": "Last year, before The Recurrence, fans gathered from their lonely worlds at RAGNAROCK to wonder whether the gods were really about to return or not. Now, as the next RAGNAROCK approaches, everyone knows things are different....",
         "releaseDate": "2015-01-21",
         "price": "$3.50",
-        "diamondSku": "NOV140697",
-        "userMetrics": {
-            "pulled": null,
-            "added": 552,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140697"
     },
     {
         "id": "6297602",
@@ -171,13 +117,7 @@
         "description": "Now the eleventh god is here, it's time to party. You're invited. Everyone's invited. We can sleep when we're dead—but when you'll be dead within two years, you may as well turn up in your pyjamas....",
         "releaseDate": "2015-02-25",
         "price": "$3.50",
-        "diamondSku": "DEC140772",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140772"
     },
     {
         "id": "3879401",
@@ -189,12 +129,6 @@
         "description": "It's time for a private audience with Ananke, she who has protected and judged the Pantheon for thousands of years. Yes, it's time for an interview... with an umpire. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes....",
         "releaseDate": "2015-03-25",
         "price": "$3.50",
-        "diamondSku": "JAN150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 548,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150721"
     }
 ]

--- a/test/shared/wish-list/test-data/sorted-issues-wish-list.json
+++ b/test/shared/wish-list/test-data/sorted-issues-wish-list.json
@@ -9,13 +9,7 @@
         "description": "It's time for a private audience with Ananke, she who has protected and judged the Pantheon for thousands of years. Yes, it's time for an interview... with an umpire. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes. Yes....",
         "releaseDate": "2015-03-25",
         "price": "$3.50",
-        "diamondSku": "JAN150721",
-        "userMetrics": {
-            "pulled": null,
-            "added": 548,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JAN150721"
     },
     {
         "id": "6297602",
@@ -27,13 +21,7 @@
         "description": "Now the eleventh god is here, it's time to party. You're invited. Everyone's invited. We can sleep when we're dead—but when you'll be dead within two years, you may as well turn up in your pyjamas....",
         "releaseDate": "2015-02-25",
         "price": "$3.50",
-        "diamondSku": "DEC140772",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "DEC140772"
     },
     {
         "id": "3056913",
@@ -45,13 +33,7 @@
         "description": "Last year, before The Recurrence, fans gathered from their lonely worlds at RAGNAROCK to wonder whether the gods were really about to return or not. Now, as the next RAGNAROCK approaches, everyone knows things are different....",
         "releaseDate": "2015-01-21",
         "price": "$3.50",
-        "diamondSku": "NOV140697",
-        "userMetrics": {
-            "pulled": null,
-            "added": 552,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "NOV140697"
     },
     {
         "id": "9626603",
@@ -63,13 +45,7 @@
         "description": "THE FAUST ACT is over. Welcome to FANDEMONIUM. The second arc of THE WICKED + THE DIVINE begins in its traditional manner (i.e. a ludicrous pun.) We'd say something like 'nothing will ever be the same again'...",
         "releaseDate": "2014-12-17",
         "price": "$3.50",
-        "diamondSku": "OCT140611",
-        "userMetrics": {
-            "pulled": null,
-            "added": 602,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "OCT140611"
     },
     {
         "id": "2489507",
@@ -81,13 +57,7 @@
         "description": "Showtime.",
         "releaseDate": "2014-10-22",
         "price": "$3.50",
-        "diamondSku": "AUG140694",
-        "userMetrics": {
-            "pulled": null,
-            "added": 607,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG140694"
     },
     {
         "id": "5518869",
@@ -99,13 +69,7 @@
         "description": "The mystery is solved. But does pop-god Lucifer like the answer? The answer is a word that rhymes with \"Go\", \"Blow\" and \"Pro\". If you think the answer rhymes with \"Cow\" I applaud you...",
         "releaseDate": "2014-09-17",
         "price": "$3.50",
-        "diamondSku": "JUL140590",
-        "userMetrics": {
-            "pulled": null,
-            "added": 618,
-            "consensusVote": 98,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL140590"
     },
     {
         "id": "7937806",
@@ -117,13 +81,7 @@
         "description": "Laura has no choice. She has to go underground to find the goth-goth-gothity-goth of the Morrigan. Is this the most ill-advised underworld-related decision since Orpheus decided to see how Eurydice was doing in the back...",
         "releaseDate": "2014-08-20",
         "price": "$3.50",
-        "diamondSku": "JUN140587",
-        "userMetrics": {
-            "pulled": null,
-            "added": 639,
-            "consensusVote": 97,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN140587"
     },
     {
         "id": "2359884",
@@ -135,13 +93,7 @@
         "description": "Diabolically divine pop-god Lucifer is in trouble. She offers superfan Laura an unprecedented deal if she helps. It's a bargain. A Faustian bargain, and they always turn out so well. Who knows who Laura will turn to...",
         "releaseDate": "2014-07-16",
         "price": "$3.50",
-        "diamondSku": "MAY140745",
-        "userMetrics": {
-            "pulled": null,
-            "added": 645,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "MAY140745"
     },
     {
         "id": "9736983",
@@ -153,13 +105,7 @@
         "description": "Ragnarock is finally here. The show to end all shows promises to be a lovely experience for all the gods... wait. Oh noes! Jamie and Matt have drawn Baphomet drenched in blood on the cover. What a hilarious internal communication...",
         "releaseDate": "2015-05-06",
         "price": "$3.50",
-        "diamondSku": "FEB150648",
-        "userMetrics": {
-            "pulled": null,
-            "added": 545,
-            "consensusVote": 99,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB150648"
     },
     {
         "id": "9999868",
@@ -171,13 +117,7 @@
         "description": "Every ninety years, twelve gods incarnate as teenagers. They are loved. They are hated. In two years, they are dead. The team behind critically thermonuclear floor-fillers Young Avengers and PHONOGRAM reunite to start a...",
         "releaseDate": "2014-06-18",
         "price": "$3.50",
-        "diamondSku": "APR140486",
-        "userMetrics": {
-            "pulled": null,
-            "added": 677,
-            "consensusVote": 96,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "APR140486"
     },
     {
         "id": "5765063",
@@ -189,13 +129,7 @@
         "description": "Dan Harmon & Justin Roiland's hilarious hit Adult Swim animated show RICK & MORTY now has its own comic book series from Oni Press! Join degenerate superscientist Rick Sanchez as he embarks on all-new insane adventures with...",
         "releaseDate": "2015-04-01",
         "price": "$3.99",
-        "diamondSku": "FEB151518",
-        "userMetrics": {
-            "pulled": null,
-            "added": 251,
-            "consensusVote": 93,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB151518"
     },
     {
         "id": "6262600",
@@ -207,13 +141,7 @@
         "description": "HERE COMES THE TSUM! The worldwide phenomenon comes to a close with a bang! Will the Tsum Tsum make it out of their trip to Earth?! And! What will be the fate of the children living in THE BLOCK when Ultron returns?!",
         "releaseDate": "2016-11-23",
         "price": "$3.99",
-        "diamondSku": "SEP161099",
-        "userMetrics": {
-            "pulled": null,
-            "added": 48,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "SEP161099"
     },
     {
         "id": "7383614",
@@ -225,13 +153,7 @@
         "description": "TSUM TSUM CIVIL WAR?!  The Tsum Tsums square off with foes you'd never expect - including each other!",
         "releaseDate": "2016-10-26",
         "price": "$3.99",
-        "diamondSku": "AUG160957",
-        "userMetrics": {
-            "pulled": null,
-            "added": 63,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "AUG160957"
     },
     {
         "id": "6157347",
@@ -243,13 +165,7 @@
         "description": "THE VILLAINOUS TSUM TSUMS MAKE THEIR PRESENCE KNOWN!\n\n\t\n\t\tStill learning about Earth, some of the Tsum Tsums take inspiration fromthe less noble superhumans…and cause about as much mayhem!",
         "releaseDate": "2016-09-07",
         "price": "$3.99",
-        "diamondSku": "JUL160965",
-        "userMetrics": {
-            "pulled": null,
-            "added": 69,
-            "consensusVote": 100,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUL160965"
     },
     {
         "id": "6146985",
@@ -261,13 +177,7 @@
         "description": "In case you've been living under a rock, Tsum Tsums are HUGE! Well, not LITERALLY (they're actually pretty tiny) but these seemingly cute and cuddly creatures are sweeping the globe! So what happens when these pint-sized...",
         "releaseDate": "2016-08-03",
         "price": "$3.99",
-        "diamondSku": "JUN160823",
-        "userMetrics": {
-            "pulled": null,
-            "added": 102,
-            "consensusVote": 75,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "JUN160823"
     },
     {
         "id": "9203306",
@@ -279,12 +189,6 @@
         "description": "SERIES PREMIERE Zelda was born in a world of dreams, and hers burned bigger than anyone had ever seen. Now she's on the run in our world, the dreams broken in her hands. But the pieces are for sale, the rich and the...",
         "releaseDate": "2017-04-05",
         "price": "$3.99",
-        "diamondSku": "FEB170540",
-        "userMetrics": {
-            "pulled": null,
-            "added": 245,
-            "consensusVote": 83,
-            "pickOfTheWeekVote": null
-        }
+        "diamondSku": "FEB170540"
     }
 ]

--- a/test/utils/custom-matchers.js
+++ b/test/utils/custom-matchers.js
@@ -235,7 +235,8 @@ module.exports = {
 
   toMatchJsonSnapshot() {
     return {
-      compare(actual, snapshotName) {
+      compare(input, snapshotName) {
+        const actual = _.map(input, value => _.omit(value, "userMetrics"));
         const snapshotPath = getSnapshotPath(snapshotName);
         let snapshotData;
 


### PR DESCRIPTION
User metrics may change often - they'll get checked as part of the comic issue check that runs. To prevent churn in snapshotting, let's omit them.